### PR TITLE
💄 Design: 약관 페이지 헤더 컴포넌트 병합

### DIFF
--- a/src/features/register/shared/components/layouts/RegisterHeader.tsx
+++ b/src/features/register/shared/components/layouts/RegisterHeader.tsx
@@ -5,12 +5,14 @@ import { View, Text } from 'react-native';
 interface RegisterHeaderProps {
   main: string;
   sub: string;
+  reverse?: boolean;
   variant?: 'default' | 'code';
 }
 
 const RegisterHeader = ({
   main,
   sub,
+  reverse = false,
   variant = 'default',
 }: RegisterHeaderProps) => {
   if (variant === 'code') {
@@ -24,10 +26,19 @@ const RegisterHeader = ({
     );
   }
 
+  const firstText = reverse ? sub : main;
+  const secondText = reverse ? main : sub;
+  const firstStyle = reverse
+    ? 'text-main-text typo-title-26-bold'
+    : 'text-surface-600 typo-sub-title-18-medium';
+  const secondStyle = reverse
+    ? 'text-surface-600 typo-sub-title-18-medium'
+    : 'text-main-text typo-title-26-bold';
+
   return (
     <View className="space-y-1 pl-[30px]">
-      <Text className="text-surface-600 typo-sub-title-18-medium">{main}</Text>
-      <Text className="text-main-text typo-title-26-bold">{sub}</Text>
+      <Text className={firstStyle}>{firstText}</Text>
+      <Text className={secondStyle}>{secondText}</Text>
     </View>
   );
 };

--- a/src/screens/Terms/index.tsx
+++ b/src/screens/Terms/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { ScrollView, Text } from 'react-native';
+import { ScrollView } from 'react-native';
 
 import useTerms from '../../features/terms/hooks/useTerms';
 
 import RegisterDefaultLayout from '@/features/register/shared/components/layouts/RegisterDefaultLayout';
+import RegisterHeader from '@/features/register/shared/components/layouts/RegisterHeader';
 import TermsSection from '@/features/terms/components/TermsSection';
 import HeaderWithBack from '@/shared/components/layouts/HeaderWithBack';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
@@ -17,17 +18,15 @@ const TermsScreen = () => {
     <ScreenLayout>
       <HeaderWithBack />
       <RegisterDefaultLayout>
+        <RegisterHeader
+          reverse
+          main="설명 및 약관을 이해하였음을 확인합니다."
+          sub={`계정을 만들기 위해
+약관에 동의해주세요.`}
+        />
         <ScrollView className="w-full px-9">
-          <Text className="typo-title-26-bold">
-            {'계정을 만들기 위해\n약관에 동의해주세요.'}
-          </Text>
-          <Text className="mt-1 text-gray-600 typo-sub-title-18-medium">
-            설명 및 약관을 이해하였음을 확인합니다.
-          </Text>
-
           <TermsSection state={state} toggle={toggle} agreeAll={agreeAll} />
         </ScrollView>
-
         <HUButton
           className="self-center"
           text="확인"


### PR DESCRIPTION
## 이슈 번호
> #21 

## 작업 내용 및 테스트 방법

- 기본 헤더에 reverse props를 추가하여 상하 텍스트 위치를 반전할 수 있게끔 분기처리 하였습니다.
- 해당 내용을 기반으로 약관동의 페이지에 헤더 디자인을 적용하였습니다.

<img width="390" height="1000" alt="simulator_screenshot_80FF8F0C-DE27-48C8-AD21-0788E60165B3" src="https://github.com/user-attachments/assets/11a92ab7-8be7-4714-b1fc-fbe0d7266c50" />