### PR TITLE
✨ Feat: user flow 비즈니스 로직 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import MainStack from '@/navigation/RootNavigator';
+import OnboardRoute from '@/navigation/stacks/OnBoardStackNavigation.';
 import { AppProviders } from '@/providers/AppProviders';
+import { useUserStore } from '@/shared/stores/user';
 
 function App() {
+  const { refreshToken } = useUserStore();
+
   return (
     <AppProviders>
-      <MainStack />
+      {refreshToken ? <MainStack /> : <OnboardRoute />}
     </AppProviders>
   );
 }

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -2,23 +2,18 @@ import React from 'react';
 
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import SignupRoute from './stacks/SignupStackNavigator';
+import OnboardRoute from './stacks/OnBoardStackNavigation.';
 import HomeTabScreens from './tabs/TabNavigator';
 import { MainNavigationProps } from './types/navigationTypes';
-
-import LoginScreen from '@/screens/Login';
-import OnboardingScreen from '@/screens/Onboarding';
 
 const Stack = createNativeStackNavigator<MainNavigationProps>();
 
 const MainStack = () => {
   return (
     <Stack.Navigator
-      initialRouteName="Onboarding" // 자동로그인 구현 시 -> Home으로 변경
+      initialRouteName="HomeRoute"
       screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
-      <Stack.Screen name="Login" component={LoginScreen} />
-      <Stack.Screen name="SignupRoute" component={SignupRoute} />
+      <Stack.Screen name="OnboardRoute" component={OnboardRoute} />
 
       <Stack.Screen name="HomeRoute" component={HomeTabScreens} />
     </Stack.Navigator>

--- a/src/navigation/stacks/OnboardStackNavigation..tsx
+++ b/src/navigation/stacks/OnboardStackNavigation..tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { OnboardNavigationProps } from '../types/navigationTypes';
+
+import SignupRoute from './SignupStackNavigator';
+
+import LoginScreen from '@/screens/Login';
+import OnboardingScreen from '@/screens/Onboarding';
+
+const Stack = createNativeStackNavigator<OnboardNavigationProps>();
+
+const OnboardRoute = () => {
+  return (
+    <Stack.Navigator
+      initialRouteName="Onboarding"
+      screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+      <Stack.Screen name="Login" component={LoginScreen} />
+
+      <Stack.Screen name="SignupRoute" component={SignupRoute} />
+    </Stack.Navigator>
+  );
+};
+
+export default OnboardRoute;

--- a/src/navigation/types/navigationTypes.ts
+++ b/src/navigation/types/navigationTypes.ts
@@ -1,8 +1,7 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 export type MainNavigationProps = {
-  Onboarding: undefined;
-  Login: undefined;
+  OnboardRoute: undefined;
   SignupRoute: undefined;
   HomeRoute: undefined;
 };
@@ -16,8 +15,17 @@ export type SignupNavigationProps = {
   SignupSuccess: undefined;
 };
 
+export type OnboardNavigationProps = {
+  Onboarding: undefined;
+  Login: undefined;
+  SignupRoute: undefined;
+};
+
 export type MainStackNavigationProp =
   NativeStackNavigationProp<MainNavigationProps>;
 
 export type SignupStackNavigationProp =
   NativeStackNavigationProp<SignupNavigationProps>;
+
+export type OnboardStackNavigationProp =
+  NativeStackNavigationProp<OnboardNavigationProps>;

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -8,7 +8,7 @@ import ButtonView from './ButtonView';
 import PaginationView from './PaginationView';
 import TextView from './TextView';
 
-import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
+import { OnboardStackNavigationProp } from '@/navigation/types/navigationTypes';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import ONBOARDING_PROVIDER from '@/shared/constants/onboardingProvider';
 
@@ -16,7 +16,7 @@ const OnboardingScreen = () => {
   const [currentStep, setCurrentStep] = useState(0);
   const progress = useSharedValue<number>(0);
   const onboardingProvider = ONBOARDING_PROVIDER;
-  const navigation = useNavigation<MainStackNavigationProp>();
+  const navigation = useNavigation<OnboardStackNavigationProp>();
 
   const movePageByIndex = (index: number) => {
     const length = onboardingProvider.length;

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -1,5 +1,9 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import Config from 'react-native-config';
+
+import { useUserStore } from '../stores/user';
+
+import { Refresh, ResponseTypes } from './types';
 
 export const axiosInstance = axios.create({
   baseURL: Config.API_KEY,
@@ -9,65 +13,69 @@ export const axiosInstance = axios.create({
 });
 
 // accessToken Header interceptor
-// axiosInstance.interceptors.request.use(
-//   config => {
-//     const accessToken = useUserStore.getState().accessToken;
+axiosInstance.interceptors.request.use(
+  config => {
+    const accessToken = useUserStore.getState().accessToken;
 
-//     console.log(accessToken);
+    console.log(accessToken);
 
-//     if (accessToken) {
-//       config.headers.Authorization = `Bearer ${accessToken}`;
-//     }
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
 
-//     console.log('axios config : ', config);
+    console.log('axios config : ', config);
 
-//     return config;
-//   },
+    return config;
+  },
 
-//   error => {
-//     console.log('axios config : ', error);
-//     return Promise.reject(error);
-//   },
-// );
+  error => {
+    console.log('axios config : ', error);
+    return Promise.reject(error);
+  },
+);
 
-// // accessToken 재발급 interceptor
-// axiosInstance.interceptors.response.use(
-//   response => response,
-//   async error => {
-//     const { refreshToken, setAccessToken, logout } = useUserStore.getState();
+// accessToken 재발급 interceptor
+axiosInstance.interceptors.response.use(
+  response => response,
+  async (error: AxiosError<ResponseTypes>) => {
+    const { refreshToken, setAccessToken, logout } = useUserStore.getState();
 
-//     // 리프레시 토큰 만료 → 로그아웃 처리 -> MainStack에서 관리
-//     if (error.response?.status === 1002) {
-//       logout();
-//       return Promise.reject(error);
-//     }
+    const code = error.response.data.responseCode;
 
-//     // 액세스 토큰 만료 → 재발급
-//     if (error.response?.status === 1001) {
-//       try {
-//         const res = await axiosInstance.post<ResponseTypes<Refresh>>(
-//           '/auth/refresh',
-//           {},
-//           {
-//             headers: {
-//               Authorization: `Bearer ${refreshToken}`,
-//             },
-//           },
-//         );
+    console.log('axios: ', code);
 
-//         const newAccessToken = res.data.data.accessToken;
+    // 리프레시 토큰 만료 → 로그아웃 처리 -> MainStack에서 관리
+    if (code === 1002) {
+      logout();
+      return Promise.reject(error);
+    }
 
-//         setAccessToken(newAccessToken);
-//         error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+    // 액세스 토큰 만료 → 재발급
+    if (code === 1001) {
+      try {
+        const res = await axios.post<ResponseTypes<Refresh>>(
+          `${Config.API_KEY}/auth/refresh`,
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${refreshToken}`,
+            },
+          },
+        );
 
-//         return axiosInstance.request(error.config);
-//       } catch (refreshError) {
-//         // 재발급 실패 → 로그아웃 처리
-//         logout();
-//         return Promise.reject(refreshError);
-//       }
-//     }
+        const newAccessToken = res.data.data.accessToken;
 
-//     return Promise.reject(error);
-//   },
-// );
+        setAccessToken(newAccessToken);
+        error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        return axiosInstance.request(error.config);
+      } catch (refreshError) {
+        // 재발급 실패 → 로그아웃 처리
+        logout();
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -42,8 +42,6 @@ axiosInstance.interceptors.response.use(
 
     const code = error.response.data.responseCode;
 
-    console.log('axios: ', code);
-
     // 리프레시 토큰 만료 → 로그아웃 처리 -> MainStack에서 관리
     if (code === 1002) {
       logout();


### PR DESCRIPTION
## 이슈 번호

> #47 

## 작업 내용 및 테스트 방법

- UI 구현이 아니기 때문에 별도의 스크린샷은 첨부하지 못하지만, console.log() 를 활용하여 테스팅 가능합니다 👍🏻 
- 모든 API 정상적으로 사용하실 수 있으시기 때문에 우혁님께서도 API 호출 진행해주셔도 될거 같아요!
- 다만, 아직 이메일쪽 구현이 끝나지 않아서, 해당 구현만 완료되면 회원가입 절차까지 가능하실거 같습니다 💯 

## To reviewers
## Token
- access 토큰 만료시 새롭게 재발급 API 요청 이후 이전에 실패한 요청을 재요청하게끔 로직 구성하였습니다.
- refresh 토큰 만료 및 기타 토큰 재발급에서 error 발생시 logout() 처리, 온보딩 화면으로 navigation 되게끔 핸들링 구현하였습니다.

## Route 
- onboard route를 구현하였습니다.
해당 route에는 signup route가 포함되어 있으며, 주로 유저의 초기 플로우 및 회원가입, token에 대응되는 route라고 생각해주시면 될거 같아요

## 자동로그인
- 유저의 refresh token 여부를 분기하여 자동로그인 구현하였습니다.
- refresh가 있는 유저는 바로 home으로 진입합니다.
- 없는 유저는 onboard route로 진입하게 됩니다.