### PR TITLE
자기소개서 기능 개발

### DIFF
--- a/src/features/record/coverLetter/components/CoverLetterCard.tsx
+++ b/src/features/record/coverLetter/components/CoverLetterCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Clipboard from '@react-native-clipboard/clipboard';
 import { Pressable, Text, View } from 'react-native';
 
 import { shadowStyleSheet } from '@/shared/styles/shadow';
@@ -17,7 +18,7 @@ const CoverLetterCard = ({ title, content }: CoverLetterCardProps) => {
       style={shadowStyleSheet.dropShadow}>
       <View className="flex-row items-center justify-between">
         <Text className="text-surface-500 typo-caption-13-medium">{title}</Text>
-        <Pressable hitSlop={14}>
+        <Pressable hitSlop={14} onPress={() => Clipboard.setString(content)}>
           <CopyIcon width={14} height={14} color="#B7B7B7" />
         </Pressable>
       </View>

--- a/src/features/record/coverLetterList/components/CoverLetterList.tsx
+++ b/src/features/record/coverLetterList/components/CoverLetterList.tsx
@@ -38,7 +38,7 @@ const CoverLetterList = ({ coverLetters }: CoverLetterListProps) => {
               onPress={() =>
                 navigation.navigate('RecordRoute', {
                   screen: 'EditCoverLetter',
-                  params: { coverLetterId: index },
+                  params: { coverLetterIdx: index },
                 })
               }>
               <CoverLetterCard title={item.question} content={item.answer} />

--- a/src/features/record/coverLetterList/components/CoverLetterList.tsx
+++ b/src/features/record/coverLetterList/components/CoverLetterList.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
-import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { Pressable, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import CoverLetterCard from '../../coverLetter/components/CoverLetterCard';
 import { useCoverLetterCarousel } from '../hooks/useCoverLetterCarousel';
 
+import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import PaginationView from '@/screens/Onboarding/PaginationView';
 
 interface CoverLetterListProps {
@@ -16,6 +18,8 @@ const CoverLetterList = ({ coverLetters }: CoverLetterListProps) => {
   const { progress, panResponder, animatedStyle } = useCoverLetterCarousel({
     coverLetters,
   });
+
+  const navigation = useNavigation<MainStackNavigationProp>();
 
   return (
     <>
@@ -30,7 +34,15 @@ const CoverLetterList = ({ coverLetters }: CoverLetterListProps) => {
             style={{
               alignSelf: index % 2 === 0 ? 'flex-start' : 'flex-end',
             }}>
-            <CoverLetterCard title={item.question} content={item.answer} />
+            <Pressable
+              onPress={() =>
+                navigation.navigate('RecordRoute', {
+                  screen: 'EditCoverLetter',
+                  params: { coverLetterId: index },
+                })
+              }>
+              <CoverLetterCard title={item.question} content={item.answer} />
+            </Pressable>
           </View>
         ))}
       </Animated.View>

--- a/src/features/record/coverLetterList/hooks/useCoverLetterCarousel.ts
+++ b/src/features/record/coverLetterList/hooks/useCoverLetterCarousel.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { PanResponder } from 'react-native';
 import {
   useAnimatedStyle,
@@ -65,6 +67,10 @@ export const useCoverLetterCarousel = ({
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
   }));
+
+  useEffect(() => {
+    moveToPage(0);
+  }, [coverLetters]);
 
   return {
     progress,

--- a/src/features/record/editCoverLetter/api/coverLetterApi.ts
+++ b/src/features/record/editCoverLetter/api/coverLetterApi.ts
@@ -1,4 +1,8 @@
-import { CoverLetter, CoverLetterResponse } from '../types/CoverLetterType';
+import {
+  AiCoverLetterResponse,
+  CoverLetter,
+  CoverLetterResponse,
+} from '../types/CoverLetterType';
 
 import { axiosInstance } from '@/shared/api/axiosInstance';
 
@@ -15,7 +19,7 @@ export const generateCoverLetterByAI = async ({
 }: {
   role: string;
   question: string;
-}) => {
+}): Promise<AiCoverLetterResponse> => {
   const response = await axiosInstance.post('/cover-letter/ai-cover-letter', {
     role,
     question,

--- a/src/features/record/editCoverLetter/api/coverLetterApi.ts
+++ b/src/features/record/editCoverLetter/api/coverLetterApi.ts
@@ -39,3 +39,11 @@ export const deleteCoverLetter = async (coverLetterId: number) => {
 
   return response.data;
 };
+
+export const getAiGenerateCount = async () => {
+  const response = await axiosInstance.get(
+    '/cover-letter/ai-cover-letter/remaining',
+  );
+
+  return response.data;
+};

--- a/src/features/record/editCoverLetter/api/coverLetterApi.ts
+++ b/src/features/record/editCoverLetter/api/coverLetterApi.ts
@@ -1,0 +1,37 @@
+import { CoverLetter, CoverLetterResponse } from '../types/CoverLetterType';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const getCoverLetter = async (): Promise<CoverLetterResponse> => {
+  const response = await axiosInstance.get('/cover-letter');
+
+  console.log('getCoverLetter response:', response);
+  return response.data;
+};
+
+export const generateCoverLetterByAI = async ({
+  role,
+  question,
+}: {
+  role: string;
+  question: string;
+}) => {
+  const response = await axiosInstance.post('/cover-letter/ai-cover-letter', {
+    role,
+    question,
+  });
+
+  return response.data;
+};
+
+export const saveCoverLetter = async (data: CoverLetter[]) => {
+  const response = await axiosInstance.post('/cover-letter', data);
+
+  return response.data;
+};
+
+export const deleteCoverLetter = async (coverLetterId: number) => {
+  const response = await axiosInstance.delete(`/cover-letter/${coverLetterId}`);
+
+  return response.data;
+};

--- a/src/features/record/editCoverLetter/components/AiErrorModal.tsx
+++ b/src/features/record/editCoverLetter/components/AiErrorModal.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { Modal, Pressable, Text, View } from 'react-native';
+
+import StatusIcons from '@/shared/icons/StatusIcons';
+
+type AiErrorType = 'limitExceeded' | 'noReview' | null;
+
+interface Props {
+  visible: boolean;
+  errorType: AiErrorType;
+  onClose: () => void;
+}
+
+const AiErrorModal = ({ visible, errorType, onClose }: Props) => {
+  const getErrorContent = () => {
+    if (errorType === 'limitExceeded') {
+      return {
+        title: (
+          <Text
+            className="mb-5 text-center text-main-text typo-sub-title-22-semibold"
+            style={{ lineHeight: 27.5 }}>
+            AI 자기소개서 생성 5회를{'\n'}모두 사용하였어요.
+          </Text>
+        ),
+      };
+    }
+
+    if (errorType === 'noReview') {
+      return {
+        title: (
+          <Text className="text-center text-surface-600 typo-caption-14-regular">
+            현재 내 후기글이 없어{'\n'}자기소개서를 생성할 수 없어요.{'\n'}
+            <Text className="font-semibold text-primary-purple">
+              후기를 1개 이상
+            </Text>
+            {' 작성 후\n자기소개서 생성을 눌러주세요.'}
+          </Text>
+        ),
+      };
+    }
+
+    return { title: '' };
+  };
+
+  const { title } = getErrorContent();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent>
+      <View className="flex-1 items-center justify-center bg-black/50">
+        <View className="w-[85%] rounded-2xl bg-white p-5">
+          <View className="mb-3 items-center">
+            <StatusIcons
+              status="caution"
+              width={30}
+              height={30}
+              color="#5B5B5B"
+            />
+          </View>
+
+          <Text
+            className="mb-5 text-center text-main-text typo-sub-title-22-semibold"
+            style={{ lineHeight: 27.5 }}>
+            {title}
+          </Text>
+
+          <Pressable
+            onPress={onClose}
+            className="items-center rounded-xl bg-primary-purple py-4">
+            <Text className="text-white typo-body-16-semibold">
+              네, 확인했어요.
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default AiErrorModal;

--- a/src/features/record/editCoverLetter/components/AiErrorModal.tsx
+++ b/src/features/record/editCoverLetter/components/AiErrorModal.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { Modal, Pressable, Text, View } from 'react-native';
 
-import StatusIcons from '@/shared/icons/StatusIcons';
+import { AiErrorType } from '../hooks/useAiCoverLetter';
 
-type AiErrorType = 'limitExceeded' | 'noReview' | null;
+import StatusIcons from '@/shared/icons/StatusIcons';
 
 interface Props {
   visible: boolean;
@@ -29,7 +29,9 @@ const AiErrorModal = ({ visible, errorType, onClose }: Props) => {
     if (errorType === 'noReview') {
       return {
         title: (
-          <Text className="text-center text-surface-600 typo-caption-14-regular">
+          <Text
+            className="mb-5 text-center text-main-text typo-sub-title-22-semibold"
+            style={{ lineHeight: 27.5 }}>
             현재 내 후기글이 없어{'\n'}자기소개서를 생성할 수 없어요.{'\n'}
             <Text className="font-semibold text-primary-purple">
               후기를 1개 이상
@@ -63,11 +65,7 @@ const AiErrorModal = ({ visible, errorType, onClose }: Props) => {
             />
           </View>
 
-          <Text
-            className="mb-5 text-center text-main-text typo-sub-title-22-semibold"
-            style={{ lineHeight: 27.5 }}>
-            {title}
-          </Text>
+          {title}
 
           <Pressable
             onPress={onClose}

--- a/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
+++ b/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
@@ -16,7 +16,6 @@ type Props = {
   onClose: () => void;
   onGenerate: (params: { role: string; question: string }) => void;
   isLoading: boolean;
-  aiGenerateCount: number;
 };
 
 const AiGenerateModal = ({
@@ -24,7 +23,6 @@ const AiGenerateModal = ({
   onClose,
   onGenerate,
   isLoading,
-  aiGenerateCount: _aiGenerateCount,
 }: Props) => {
   const [role, setRole] = useState('');
   const [question, setQuestion] = useState('');
@@ -59,7 +57,6 @@ const AiGenerateModal = ({
       <View className="flex-1 items-center justify-center bg-black/50">
         <View className="w-[85%] rounded-2xl bg-white p-5">
           {isLoading ? (
-            // 로딩 상태
             <View className="items-center py-8">
               <View className="mb-4 flex-row">
                 <ActivityIndicator size="small" color="#7248D9" />
@@ -72,7 +69,6 @@ const AiGenerateModal = ({
               </Text>
             </View>
           ) : (
-            // 입력 폼 상태
             <>
               {/* 닫기 버튼 */}
               <View className="items-end">

--- a/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
+++ b/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
@@ -34,6 +34,8 @@ const AiGenerateModal = ({
       return;
     }
     onGenerate({ role: role.trim(), question: question.trim() });
+    setRole('');
+    setQuestion('');
   };
 
   const handleClose = () => {

--- a/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
+++ b/src/features/record/editCoverLetter/components/AiGenerateModal.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import CloseIcon from '@/static/icons/close.svg';
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onGenerate: (params: { role: string; question: string }) => void;
+  isLoading: boolean;
+  aiGenerateCount: number;
+};
+
+const AiGenerateModal = ({
+  visible,
+  onClose,
+  onGenerate,
+  isLoading,
+  aiGenerateCount: _aiGenerateCount,
+}: Props) => {
+  const [role, setRole] = useState('');
+  const [question, setQuestion] = useState('');
+
+  const handleGenerate = () => {
+    if (!role.trim() || !question.trim()) {
+      return;
+    }
+    onGenerate({ role: role.trim(), question: question.trim() });
+  };
+
+  const handleClose = () => {
+    if (isLoading) {
+      return;
+    }
+    setRole('');
+    setQuestion('');
+    onClose();
+  };
+
+  const isButtonDisabled = !role.trim() || !question.trim() || isLoading;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={handleClose}
+      statusBarTranslucent={true}>
+      <View className="flex-1 items-center justify-center bg-black/50">
+        <View className="w-[85%] rounded-2xl bg-white p-5">
+          {isLoading ? (
+            // 로딩 상태
+            <View className="items-center py-8">
+              <View className="mb-4 flex-row">
+                <ActivityIndicator size="small" color="#7248D9" />
+              </View>
+              <Text className="text-center text-main-text typo-body-16-semibold">
+                잠시만 기다려주세요.
+              </Text>
+              <Text className="text-center text-main-text typo-body-16-semibold">
+                자기소개서를 작성 중이에요.
+              </Text>
+            </View>
+          ) : (
+            // 입력 폼 상태
+            <>
+              {/* 닫기 버튼 */}
+              <View className="items-end">
+                <Pressable onPress={handleClose} hitSlop={10}>
+                  <CloseIcon width={24} height={24} color="#5B5B5B" />
+                </Pressable>
+              </View>
+
+              {/* 직무 입력 */}
+              <View className="mt-2">
+                <Text className="mb-2 text-main-text typo-body-15-medium">
+                  <Text className="text-red-500">*</Text>
+                  {' 내 직무를 입력해주세요.'}
+                </Text>
+                <TextInput
+                  className="typo-body-14-regular rounded-xl border border-surface-200 bg-white px-4 py-3"
+                  placeholder="ex : 기획, 마케팅, 웹 개발 등"
+                  placeholderTextColor="#B7B7B7"
+                  value={role}
+                  onChangeText={setRole}
+                />
+              </View>
+
+              {/* 질문 입력 */}
+              <View className="mt-5">
+                <Text className="mb-2 text-main-text typo-body-15-medium">
+                  <Text className="text-red-500">*</Text>
+                  {' 질문을 입력해주세요.'}
+                </Text>
+                <TextInput
+                  className="typo-body-14-regular rounded-xl border border-surface-200 bg-white px-4 py-3"
+                  placeholder="ex : 직무를 위한 노력 및 경험"
+                  placeholderTextColor="#B7B7B7"
+                  value={question}
+                  onChangeText={setQuestion}
+                />
+              </View>
+
+              {/* 안내 문구 */}
+              <View className="mt-5">
+                <Text className="typo-caption-13-regular text-center text-surface-500">
+                  내 직무와 자기소개서 질문을 입력하면
+                </Text>
+                <Text className="typo-caption-13-regular text-center text-surface-500">
+                  기존 내용이 삭제되고, AI가 답변을 생성해요.
+                </Text>
+              </View>
+
+              {/* 생성 버튼 */}
+              <Pressable
+                onPress={handleGenerate}
+                disabled={isButtonDisabled}
+                className={`mt-5 items-center rounded-full py-[14px] ${
+                  isButtonDisabled ? 'bg-surface-300' : 'bg-primary-purple'
+                }`}>
+                <Text
+                  className={`typo-body-16-medium ${
+                    isButtonDisabled ? 'text-surface-400' : 'text-white'
+                  }`}>
+                  ✦ AI 자기소개서 생성하기
+                </Text>
+              </Pressable>
+            </>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default AiGenerateModal;

--- a/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
+++ b/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+import { View, StatusBar, Pressable, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
+import ArrowIcons from '@/shared/icons/ArrowIcons';
+
+interface CoverLetterHeaderProps {
+  title: string;
+  rightButtonText?: string;
+  onRightButtonPress?: () => void;
+}
+
+const CoverLetterHeader = ({
+  title,
+  rightButtonText,
+  onRightButtonPress,
+}: CoverLetterHeaderProps) => {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<MainStackNavigationProp>();
+
+  return (
+    <>
+      <View
+        className="absolute left-0 right-0 top-0 z-50 bg-white"
+        style={{ height: insets.top }}
+      />
+
+      <View
+        className="absolute left-0 right-0 z-50 bg-white"
+        style={{ top: insets.top, height: 74 }}>
+        <StatusBar barStyle="dark-content" />
+
+        <View className="h-full flex-row items-center justify-between px-5">
+          <Pressable
+            hitSlop={14}
+            onPress={() => {
+              navigation.goBack();
+            }}>
+            <ArrowIcons
+              direction="left"
+              width={24}
+              height={20}
+              color="#1E2128"
+            />
+          </Pressable>
+
+          <View className="absolute left-0 right-0 flex-1 items-center">
+            <Text className="text-main-text typo-sub-title-20-semibold">
+              {title}
+            </Text>
+          </View>
+
+          {rightButtonText && onRightButtonPress && (
+            <Pressable onPress={onRightButtonPress}>
+              <Text className="text-primary-purple typo-sub-title-18-medium">
+                {rightButtonText}
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </>
+  );
+};
+
+export default CoverLetterHeader;

--- a/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
+++ b/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import { useNavigation } from '@react-navigation/native';
 import { View, StatusBar, Pressable, Text } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import { cn } from '@/shared/lib/cn';
 
@@ -13,6 +11,7 @@ interface CoverLetterHeaderProps {
   rightButtonText?: string;
   isRightButtonDisabled?: boolean;
   onRightButtonPress?: () => void;
+  onBackButtonPress: () => void;
 }
 
 const CoverLetterHeader = ({
@@ -20,9 +19,9 @@ const CoverLetterHeader = ({
   rightButtonText,
   isRightButtonDisabled,
   onRightButtonPress,
+  onBackButtonPress,
 }: CoverLetterHeaderProps) => {
   const insets = useSafeAreaInsets();
-  const navigation = useNavigation<MainStackNavigationProp>();
 
   return (
     <>
@@ -37,11 +36,7 @@ const CoverLetterHeader = ({
         <StatusBar barStyle="dark-content" />
 
         <View className="h-full flex-row items-center justify-between px-5">
-          <Pressable
-            hitSlop={14}
-            onPress={() => {
-              navigation.goBack();
-            }}>
+          <Pressable hitSlop={14} onPress={onBackButtonPress}>
             <ArrowIcons
               direction="left"
               width={24}

--- a/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
+++ b/src/features/record/editCoverLetter/components/CoverLetterHeader.tsx
@@ -6,16 +6,19 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
+import { cn } from '@/shared/lib/cn';
 
 interface CoverLetterHeaderProps {
   title: string;
   rightButtonText?: string;
+  isRightButtonDisabled?: boolean;
   onRightButtonPress?: () => void;
 }
 
 const CoverLetterHeader = ({
   title,
   rightButtonText,
+  isRightButtonDisabled,
   onRightButtonPress,
 }: CoverLetterHeaderProps) => {
   const insets = useSafeAreaInsets();
@@ -54,8 +57,14 @@ const CoverLetterHeader = ({
           </View>
 
           {rightButtonText && onRightButtonPress && (
-            <Pressable onPress={onRightButtonPress}>
-              <Text className="text-primary-purple typo-sub-title-18-medium">
+            <Pressable
+              onPress={onRightButtonPress}
+              disabled={isRightButtonDisabled}>
+              <Text
+                className={cn(
+                  'text-primary-purple typo-sub-title-18-medium',
+                  isRightButtonDisabled && 'text-surface-300',
+                )}>
                 {rightButtonText}
               </Text>
             </Pressable>

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -135,6 +135,7 @@ const EditCoverLetter = () => {
                     className="rounded-[15px] border border-surface-200 bg-white px-4 py-3 typo-body-15-regular"
                     placeholder="질문을 작성해주세요."
                     placeholderTextColor="#B7B7B7"
+                    maxLength={2000}
                     value={currentItem?.question || ''}
                     onChangeText={handleQuestionChange}
                   />
@@ -147,6 +148,7 @@ const EditCoverLetter = () => {
                     placeholder="답변을 작성해주세요."
                     placeholderTextColor="#B7B7B7"
                     multiline
+                    maxLength={2000}
                     textAlignVertical="top"
                     value={currentItem?.answer || ''}
                     onChangeText={handleAnswerChange}

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -207,7 +207,6 @@ const EditCoverLetter = () => {
         onClose={closeAiModal}
         onGenerate={handleGenerateAiCoverLetter}
         isLoading={isGenerating}
-        aiGenerateCount={aiGenerateCount}
       />
 
       {/* AI 에러 모달 */}
@@ -217,6 +216,7 @@ const EditCoverLetter = () => {
         onClose={closeAiErrorModal}
       />
 
+      {/* 저장 성공 모달 */}
       <ConfirmModal
         visible={isSaveSuccessModalVisible}
         title={'저장이 완료되었어요.'}
@@ -226,6 +226,7 @@ const EditCoverLetter = () => {
         }}
       />
 
+      {/* 작성중 모달 */}
       {isOnWritingModalVisible && (
         <ConfirmModal
           visible={isOnWritingModalVisible}
@@ -244,6 +245,7 @@ const EditCoverLetter = () => {
         />
       )}
 
+      {/* 문항 삭제 모달 */}
       {isDeleteModalVisible && (
         <ConfirmModal
           visible={isDeleteModalVisible}

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -18,6 +18,8 @@ import AiGenerateModal from './AiGenerateModal';
 import CoverLetterHeader from './CoverLetterHeader';
 
 import useCoverLetterEdit from '@/features/record/editCoverLetter/hooks/useCoverLetterEdit';
+import { cn } from '@/shared/lib/cn';
+import ConfirmModal from '@/shared/ui/organisms/ConfirmModal';
 import PlusIcon from '@/static/icons/add.svg';
 import TrashIcon from '@/static/icons/trash.svg';
 
@@ -138,8 +140,20 @@ const EditCoverLetter = () => {
 
                   <Pressable
                     onPress={openAiModal}
-                    className="mt-4 rounded-full bg-primary-purple px-[27px] py-[14px]">
-                    <Text className="text-surface-200 typo-body-16-medium">
+                    disabled={aiGenerateCount === 0}
+                    className={cn(
+                      'mt-4 rounded-full px-[27px] py-[14px]',
+                      aiGenerateCount === 0
+                        ? 'bg-surface-300'
+                        : 'bg-primary-purple',
+                    )}>
+                    <Text
+                      className={cn(
+                        'typo-body-16-medium',
+                        aiGenerateCount === 0
+                          ? 'text-white'
+                          : 'text-surface-200',
+                      )}>
                       AI 자기소개서 생성 ({aiGenerateCount}/5)
                     </Text>
                   </Pressable>
@@ -174,6 +188,13 @@ const EditCoverLetter = () => {
         visible={aiErrorType !== null}
         errorType={aiErrorType}
         onClose={closeAiErrorModal}
+      />
+
+      <ConfirmModal
+        visible={true}
+        title={'저장이 완료되었어요.'}
+        confirmText={'네, 확인했어요.'}
+        onConfirm={() => {}}
       />
     </View>
   );

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   Keyboard,
@@ -13,6 +13,8 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import AiErrorModal from './AiErrorModal';
+import AiGenerateModal from './AiGenerateModal';
 import CoverLetterHeader from './CoverLetterHeader';
 
 import useCoverLetterEdit from '@/features/record/editCoverLetter/hooks/useCoverLetterEdit';
@@ -33,13 +35,15 @@ const EditCoverLetter = () => {
     selectItem,
     handleSave,
     isSaving,
+    isGenerating,
+    isAiModalVisible,
+    aiGenerateCount,
+    aiErrorType,
+    openAiModal,
+    closeAiModal,
+    closeAiErrorModal,
+    handleGenerateAiCoverLetter,
   } = useCoverLetterEdit();
-
-  const [aiGenerateCount] = useState(5);
-
-  const handleAiGenerate = () => {
-    console.log('AI 자기소개서 생성');
-  };
 
   return (
     <View className="flex-1 bg-surface-50">
@@ -133,9 +137,9 @@ const EditCoverLetter = () => {
                   </Text>
 
                   <Pressable
-                    onPress={handleAiGenerate}
-                    className="mt-4 rounded-full bg-primary-purple px-6 py-3">
-                    <Text className="text-white typo-body-15-semibold">
+                    onPress={openAiModal}
+                    className="mt-4 rounded-full bg-primary-purple px-[27px] py-[14px]">
+                    <Text className="text-surface-200 typo-body-16-medium">
                       AI 자기소개서 생성 ({aiGenerateCount}/5)
                     </Text>
                   </Pressable>
@@ -145,8 +149,8 @@ const EditCoverLetter = () => {
                 <Pressable
                   onPress={handleDeleteItem}
                   className="mt-6 flex-row items-center justify-center">
-                  <TrashIcon width={16} height={16} color="#B7B7B7" />
-                  <Text className="typo-body-14-regular ml-1 text-surface-400">
+                  <TrashIcon width={18} height={18} color="#B7B7B7" />
+                  <Text className="ml-1 text-surface-400 typo-body-15-medium">
                     문항 삭제하기
                   </Text>
                 </Pressable>
@@ -155,6 +159,22 @@ const EditCoverLetter = () => {
           </TouchableWithoutFeedback>
         </ScrollView>
       </KeyboardAvoidingView>
+
+      {/* AI 생성 모달 */}
+      <AiGenerateModal
+        visible={isAiModalVisible}
+        onClose={closeAiModal}
+        onGenerate={handleGenerateAiCoverLetter}
+        isLoading={isGenerating}
+        aiGenerateCount={aiGenerateCount}
+      />
+
+      {/* AI 에러 모달 */}
+      <AiErrorModal
+        visible={aiErrorType !== null}
+        errorType={aiErrorType}
+        onClose={closeAiErrorModal}
+      />
     </View>
   );
 };

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -31,7 +31,8 @@ const EditCoverLetter = () => {
     handleAddItem,
     handleDeleteItem,
     selectItem,
-    getRequestData,
+    handleSave,
+    isSaving,
   } = useCoverLetterEdit();
 
   const [aiGenerateCount] = useState(5);
@@ -40,16 +41,11 @@ const EditCoverLetter = () => {
     console.log('AI 자기소개서 생성');
   };
 
-  const handleSave = () => {
-    const requestData = getRequestData();
-    console.log('저장:', requestData);
-  };
-
   return (
     <View className="flex-1 bg-surface-50">
       <CoverLetterHeader
         title="내 자기소개서"
-        rightButtonText="저장"
+        rightButtonText={isSaving ? '저장 중...' : '저장'}
         onRightButtonPress={handleSave}
       />
 

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -57,6 +57,8 @@ const EditCoverLetter = () => {
 
   const [isOnWritingModalVisible, setIsOnWritingModalVisible] = useState(false);
 
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+
   useEffect(() => {
     if (isSaveSuccess) {
       setIsSaveSuccessModalVisible(true);
@@ -71,7 +73,12 @@ const EditCoverLetter = () => {
         isRightButtonDisabled={isSaving || !isDirty}
         onRightButtonPress={handleSave}
         onBackButtonPress={() => {
-          setIsOnWritingModalVisible(true);
+          if (isDirty) {
+            setIsOnWritingModalVisible(true);
+            return;
+          } else {
+            navigation.goBack();
+          }
         }}
       />
 
@@ -181,7 +188,7 @@ const EditCoverLetter = () => {
 
                 {/* 문항 삭제 버튼 */}
                 <Pressable
-                  onPress={handleDeleteItem}
+                  onPress={() => setIsDeleteModalVisible(true)}
                   className="mt-6 flex-row items-center justify-center">
                   <TrashIcon width={18} height={18} color="#B7B7B7" />
                   <Text className="ml-1 text-surface-400 typo-body-15-medium">
@@ -233,6 +240,22 @@ const EditCoverLetter = () => {
           }}
           onCancel={() => {
             setIsOnWritingModalVisible(false);
+          }}
+        />
+      )}
+
+      {isDeleteModalVisible && (
+        <ConfirmModal
+          visible={isDeleteModalVisible}
+          title={'해당 문항을 삭제할까요?'}
+          confirmText={'네, 삭제할래요.'}
+          cancelText={'아니요, 그대로 둘게요.'}
+          onConfirm={() => {
+            handleDeleteItem();
+            setIsDeleteModalVisible(false);
+          }}
+          onClose={() => {
+            setIsDeleteModalVisible(false);
           }}
         />
       )}

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { useNavigation } from '@react-navigation/native';
 import {
   Keyboard,
   KeyboardAvoidingView,
@@ -18,6 +19,7 @@ import AiGenerateModal from './AiGenerateModal';
 import CoverLetterHeader from './CoverLetterHeader';
 
 import useCoverLetterEdit from '@/features/record/editCoverLetter/hooks/useCoverLetterEdit';
+import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import { cn } from '@/shared/lib/cn';
 import ConfirmModal from '@/shared/ui/organisms/ConfirmModal';
 import PlusIcon from '@/static/icons/add.svg';
@@ -25,6 +27,7 @@ import TrashIcon from '@/static/icons/trash.svg';
 
 const EditCoverLetter = () => {
   const insets = useSafeAreaInsets();
+  const navigation = useNavigation<MainStackNavigationProp>();
 
   const {
     coverLetters,
@@ -52,6 +55,8 @@ const EditCoverLetter = () => {
   const [isSaveSuccessModalVisible, setIsSaveSuccessModalVisible] =
     useState(false);
 
+  const [isOnWritingModalVisible, setIsOnWritingModalVisible] = useState(false);
+
   useEffect(() => {
     if (isSaveSuccess) {
       setIsSaveSuccessModalVisible(true);
@@ -65,6 +70,9 @@ const EditCoverLetter = () => {
         rightButtonText={isSaving ? '저장 중...' : '저장'}
         isRightButtonDisabled={isSaving || !isDirty}
         onRightButtonPress={handleSave}
+        onBackButtonPress={() => {
+          setIsOnWritingModalVisible(true);
+        }}
       />
 
       <KeyboardAvoidingView
@@ -210,6 +218,24 @@ const EditCoverLetter = () => {
           setIsSaveSuccessModalVisible(false);
         }}
       />
+
+      {isOnWritingModalVisible && (
+        <ConfirmModal
+          visible={isOnWritingModalVisible}
+          title={'작성 중인 내용이 있어요.\n이대로 나갈까요?'}
+          confirmText={'아니요, 계속 작성할래요.'}
+          cancelText={'네, 이대로 나갈게요.'}
+          onClose={() => {
+            navigation.goBack();
+          }}
+          onConfirm={() => {
+            setIsOnWritingModalVisible(false);
+          }}
+          onCancel={() => {
+            setIsOnWritingModalVisible(false);
+          }}
+        />
+      )}
     </View>
   );
 };

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Keyboard,
@@ -37,6 +37,7 @@ const EditCoverLetter = () => {
     selectItem,
     handleSave,
     isSaving,
+    isSaveSuccess,
     isGenerating,
     isAiModalVisible,
     aiGenerateCount,
@@ -45,13 +46,24 @@ const EditCoverLetter = () => {
     closeAiModal,
     closeAiErrorModal,
     handleGenerateAiCoverLetter,
+    isDirty,
   } = useCoverLetterEdit();
+
+  const [isSaveSuccessModalVisible, setIsSaveSuccessModalVisible] =
+    useState(false);
+
+  useEffect(() => {
+    if (isSaveSuccess) {
+      setIsSaveSuccessModalVisible(true);
+    }
+  }, [isSaveSuccess]);
 
   return (
     <View className="flex-1 bg-surface-50">
       <CoverLetterHeader
         title="내 자기소개서"
         rightButtonText={isSaving ? '저장 중...' : '저장'}
+        isRightButtonDisabled={isSaving || !isDirty}
         onRightButtonPress={handleSave}
       />
 
@@ -191,10 +203,12 @@ const EditCoverLetter = () => {
       />
 
       <ConfirmModal
-        visible={true}
+        visible={isSaveSuccessModalVisible}
         title={'저장이 완료되었어요.'}
         confirmText={'네, 확인했어요.'}
-        onConfirm={() => {}}
+        onConfirm={() => {
+          setIsSaveSuccessModalVisible(false);
+        }}
       />
     </View>
   );

--- a/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/components/EditCoverLetter.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import CoverLetterHeader from './CoverLetterHeader';
+
+import useCoverLetterEdit from '@/features/record/editCoverLetter/hooks/useCoverLetterEdit';
+import PlusIcon from '@/static/icons/add.svg';
+import TrashIcon from '@/static/icons/trash.svg';
+
+const EditCoverLetter = () => {
+  const insets = useSafeAreaInsets();
+
+  const {
+    coverLetters,
+    currentIndex,
+    currentItem,
+    handleQuestionChange,
+    handleAnswerChange,
+    handleAddItem,
+    handleDeleteItem,
+    selectItem,
+    getRequestData,
+  } = useCoverLetterEdit();
+
+  const [aiGenerateCount] = useState(5);
+
+  const handleAiGenerate = () => {
+    console.log('AI 자기소개서 생성');
+  };
+
+  const handleSave = () => {
+    const requestData = getRequestData();
+    console.log('저장:', requestData);
+  };
+
+  return (
+    <View className="flex-1 bg-surface-50">
+      <CoverLetterHeader
+        title="내 자기소개서"
+        rightButtonText="저장"
+        onRightButtonPress={handleSave}
+      />
+
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={0}>
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+          <View style={{ height: insets.top + 74 }} />
+          <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+            <View className="flex-1 flex-col justify-between">
+              {/* 상단 영역 */}
+              <View>
+                {/* 탭 버튼 영역 */}
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  nestedScrollEnabled={true}
+                  contentContainerStyle={{
+                    paddingHorizontal: 20,
+                    paddingVertical: 16,
+                  }}>
+                  <View className="flex-row items-center">
+                    {coverLetters.map((_, index) => (
+                      <Pressable
+                        key={index}
+                        onPress={() => selectItem(index)}
+                        className={`mr-2 h-[36px] w-[36px] items-center justify-center rounded-2xl ${
+                          currentIndex === index
+                            ? 'bg-primary-purple'
+                            : 'border-[1.5px] border-primary-purple bg-white'
+                        }`}>
+                        <Text
+                          className={`typo-body-16-semibold ${
+                            currentIndex === index
+                              ? 'text-white'
+                              : 'text-primary-purple'
+                          }`}>
+                          {index + 1}
+                        </Text>
+                      </Pressable>
+                    ))}
+                    <Pressable
+                      onPress={handleAddItem}
+                      className="h-[36px] w-[36px] items-center justify-center rounded-2xl border border-surface-300">
+                      <PlusIcon width={16} height={16} color="#B7B7B7" />
+                    </Pressable>
+                  </View>
+                </ScrollView>
+
+                {/* 질문 입력 */}
+                <View className="px-5">
+                  <TextInput
+                    className="rounded-[15px] border border-surface-200 bg-white px-4 py-3 typo-body-15-regular"
+                    placeholder="질문을 작성해주세요."
+                    placeholderTextColor="#B7B7B7"
+                    value={currentItem?.question || ''}
+                    onChangeText={handleQuestionChange}
+                  />
+                </View>
+
+                {/* 답변 입력 */}
+                <View className="mt-4 px-5">
+                  <TextInput
+                    className="h-[280px] rounded-[15px] border border-surface-200 bg-white px-4 py-3 typo-body-15-regular"
+                    placeholder="답변을 작성해주세요."
+                    placeholderTextColor="#B7B7B7"
+                    multiline
+                    textAlignVertical="top"
+                    value={currentItem?.answer || ''}
+                    onChangeText={handleAnswerChange}
+                  />
+                </View>
+              </View>
+
+              {/* 하단 영역 */}
+              <View style={{ paddingBottom: insets.bottom + 20 }}>
+                {/* AI 생성 영역 */}
+                <View className="mt-6 items-center px-5">
+                  <Text className="text-center text-surface-500 typo-body-16-medium">
+                    하이유니가 내 후기글을 바탕으로
+                  </Text>
+                  <Text className="text-center text-surface-500 typo-body-16-medium">
+                    자기소개를 작성해드려요!
+                  </Text>
+
+                  <Pressable
+                    onPress={handleAiGenerate}
+                    className="mt-4 rounded-full bg-primary-purple px-6 py-3">
+                    <Text className="text-white typo-body-15-semibold">
+                      AI 자기소개서 생성 ({aiGenerateCount}/5)
+                    </Text>
+                  </Pressable>
+                </View>
+
+                {/* 문항 삭제 버튼 */}
+                <Pressable
+                  onPress={handleDeleteItem}
+                  className="mt-6 flex-row items-center justify-center">
+                  <TrashIcon width={16} height={16} color="#B7B7B7" />
+                  <Text className="typo-body-14-regular ml-1 text-surface-400">
+                    문항 삭제하기
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          </TouchableWithoutFeedback>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+};
+
+export default EditCoverLetter;

--- a/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
+++ b/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
@@ -1,0 +1,77 @@
+import { CoverLetter } from '../types/CoverLetterType';
+
+export type State = {
+  coverLetters: CoverLetter[];
+  currentIndex: number;
+};
+
+export type Action =
+  | { type: 'INIT_FROM_SERVER'; payload: CoverLetter[] }
+  | { type: 'UPDATE_QUESTION'; payload: { index: number; text: string } }
+  | { type: 'UPDATE_ANSWER'; payload: { index: number; text: string } }
+  | { type: 'ADD_ITEM'; payload: CoverLetter }
+  | { type: 'DELETE_ITEM'; payload: { index: number } }
+  | { type: 'SET_INDEX'; payload: { index: number } };
+
+export const coverLetterReducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'INIT_FROM_SERVER':
+      return {
+        coverLetters: action.payload,
+        currentIndex: 0,
+      };
+
+    case 'UPDATE_QUESTION': {
+      const { index, text } = action.payload;
+      const updated = [...state.coverLetters];
+      const item = updated[index];
+
+      if (!item) {
+        return state;
+      }
+      updated[index] = { ...item, question: text };
+
+      return { ...state, coverLetters: updated };
+    }
+
+    case 'UPDATE_ANSWER': {
+      const { index, text } = action.payload;
+      const updated = [...state.coverLetters];
+      const item = updated[index];
+
+      if (!item) {
+        return state;
+      }
+      updated[index] = { ...item, answer: text };
+
+      return { ...state, coverLetters: updated };
+    }
+
+    case 'ADD_ITEM':
+      return {
+        coverLetters: [...state.coverLetters, action.payload],
+        currentIndex: state.currentIndex + 1,
+      };
+
+    case 'DELETE_ITEM': {
+      if (state.coverLetters.length <= 1) {
+        return state;
+      }
+
+      const filtered = state.coverLetters.filter(
+        (_, idx) => idx !== action.payload.index,
+      );
+
+      return {
+        coverLetters: filtered,
+        currentIndex: Math.max(0, state.currentIndex - 1),
+      };
+    }
+
+    case 'SET_INDEX':
+      return { ...state, currentIndex: action.payload.index };
+
+    default:
+      return state;
+  }
+};

--- a/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
+++ b/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
@@ -48,6 +48,10 @@ export const coverLetterReducer = (state: State, action: Action): State => {
     }
 
     case 'ADD_ITEM':
+      if (state.coverLetters.length >= 10) {
+        return state;
+      }
+
       return {
         coverLetters: [...state.coverLetters, action.payload],
         currentIndex: state.currentIndex + 1,

--- a/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
+++ b/src/features/record/editCoverLetter/hooks/coverLetterReducer.ts
@@ -54,7 +54,7 @@ export const coverLetterReducer = (state: State, action: Action): State => {
 
       return {
         coverLetters: [...state.coverLetters, action.payload],
-        currentIndex: state.currentIndex + 1,
+        currentIndex: state.coverLetters.length,
       };
 
     case 'DELETE_ITEM': {

--- a/src/features/record/editCoverLetter/hooks/useAiCoverLetter.ts
+++ b/src/features/record/editCoverLetter/hooks/useAiCoverLetter.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { AxiosError } from 'axios';
+
+import { getAiGenerateCount } from '../api/coverLetterApi';
+import { AiCoverLetterResponse } from '../types/CoverLetterType';
+
+import useCoverLetterMutation from './useCoverLetterMutation';
+
+export type AiErrorType = 'limitExceeded' | 'noReview' | null;
+
+type UseAiCoverLetterParams = {
+  onSuccess: (question: string, answer: string) => void;
+};
+
+const useAiCoverLetter = ({ onSuccess }: UseAiCoverLetterParams) => {
+  const [isAiModalVisible, setIsAiModalVisible] = useState(false);
+  const [aiGenerateCount, setAiGenerateCount] = useState(5);
+  const [aiErrorType, setAiErrorType] = useState<AiErrorType>(null);
+
+  const { generateAiCoverLetterAsync, isGenerating } = useCoverLetterMutation();
+
+  useEffect(() => {
+    getAiGenerateCount().then(data => {
+      setAiGenerateCount(data.data.coverletterCnt);
+    });
+  }, []);
+
+  const openAiModal = useCallback(() => {
+    setIsAiModalVisible(true);
+  }, []);
+
+  const closeAiModal = useCallback(() => {
+    setIsAiModalVisible(false);
+  }, []);
+
+  const closeAiErrorModal = useCallback(() => {
+    setAiErrorType(null);
+  }, []);
+
+  const handleGenerateAiCoverLetter = useCallback(
+    async ({ role, question }: { role: string; question: string }) => {
+      try {
+        const result: AiCoverLetterResponse = await generateAiCoverLetterAsync({
+          role,
+          question,
+        });
+
+        if (result?.data?.answer) {
+          onSuccess(question, result.data.answer);
+        }
+        if (result?.data?.coverletterCnt !== undefined) {
+          setAiGenerateCount(result.data.coverletterCnt);
+        }
+        setIsAiModalVisible(false);
+
+        return result;
+      } catch (e) {
+        setIsAiModalVisible(false);
+
+        if (e instanceof AxiosError && e.response) {
+          const status = e.response.status;
+
+          if (status === 403) {
+            setAiErrorType('limitExceeded');
+            return;
+          }
+
+          if (status === 404) {
+            setAiErrorType('noReview');
+            return;
+          }
+        }
+
+        throw e;
+      }
+    },
+    [generateAiCoverLetterAsync, onSuccess],
+  );
+
+  return {
+    isAiModalVisible,
+    aiGenerateCount,
+    aiErrorType,
+    isGenerating,
+    openAiModal,
+    closeAiModal,
+    closeAiErrorModal,
+    handleGenerateAiCoverLetter,
+  };
+};
+
+export default useAiCoverLetter;

--- a/src/features/record/editCoverLetter/hooks/useAiCoverLetter.ts
+++ b/src/features/record/editCoverLetter/hooks/useAiCoverLetter.ts
@@ -71,8 +71,6 @@ const useAiCoverLetter = ({ onSuccess }: UseAiCoverLetterParams) => {
             return;
           }
         }
-
-        throw e;
       }
     },
     [generateAiCoverLetterAsync, onSuccess],

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,8 +1,9 @@
 import { useReducer, useCallback, useEffect, useState } from 'react';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
+import { AxiosError } from 'axios';
 
-import { CoverLetter } from '../types/CoverLetterType';
+import { AiCoverLetterResponse, CoverLetter } from '../types/CoverLetterType';
 
 import { coverLetterReducer } from './coverLetterReducer';
 import useCoverLetterMutation from './useCoverLetterMutation';
@@ -15,15 +16,27 @@ type EditCoverLetterRouteProp = RouteProp<
   'EditCoverLetter'
 >;
 
+type AiErrorType = 'limitExceeded' | 'noReview' | null;
+
 const useCoverLetterEdit = () => {
   const route = useRoute<EditCoverLetterRouteProp>();
   const coverLetterId = route.params?.coverLetterId;
   const isEditMode = coverLetterId !== undefined;
   const [deleteIdList, setDeleteIdList] = useState<number[]>([]);
 
+  const [isAiModalVisible, setIsAiModalVisible] = useState(false);
+  const [aiGenerateCount, setAiGenerateCount] = useState(5);
+  const [aiErrorType, setAiErrorType] = useState<AiErrorType>(null);
+
   const { coverLetterData, coverLetterLoading } = useCoverLetterQueries();
-  const { saveCoverLetter, isSaving, isSaveSuccess, deleteCoverLetter } =
-    useCoverLetterMutation();
+  const {
+    saveCoverLetter,
+    isSaving,
+    isSaveSuccess,
+    deleteCoverLetter,
+    generateAiCoverLetterAsync,
+    isGenerating,
+  } = useCoverLetterMutation();
 
   const [state, dispatch] = useReducer(coverLetterReducer, {
     coverLetters: [createNewCoverLetter()],
@@ -129,6 +142,63 @@ const useCoverLetterEdit = () => {
     });
   }, [getRequestData, saveCoverLetter, deleteCoverLetter, deleteIdList]);
 
+  // AI 모달 열기
+  const openAiModal = useCallback(() => {
+    setIsAiModalVisible(true);
+  }, []);
+
+  // AI 모달 닫기
+  const closeAiModal = useCallback(() => {
+    setIsAiModalVisible(false);
+  }, []);
+
+  // 에러 모달 닫기
+  const closeAiErrorModal = useCallback(() => {
+    setAiErrorType(null);
+  }, []);
+
+  // AI 자기소개서 생성
+  const handleGenerateAiCoverLetter = useCallback(
+    async ({ role, question }: { role: string; question: string }) => {
+      try {
+        const result: AiCoverLetterResponse = await generateAiCoverLetterAsync({
+          role,
+          question,
+        });
+
+        if (result?.data?.answer) {
+          handleAnswerChange(result.data.answer);
+        }
+        if (result?.data?.coverletterCnt !== undefined) {
+          setAiGenerateCount(result.data.coverletterCnt);
+        }
+        setIsAiModalVisible(false);
+
+        return result;
+      } catch (e) {
+        console.error('AI generate error:', e);
+        setIsAiModalVisible(false);
+
+        if (e instanceof AxiosError && e.response) {
+          const status = e.response.status;
+
+          if (status === 403) {
+            setAiErrorType('limitExceeded');
+            return;
+          }
+
+          if (status === 404) {
+            setAiErrorType('noReview');
+            return;
+          }
+        }
+
+        throw e;
+      }
+    },
+    [generateAiCoverLetterAsync, handleAnswerChange],
+  );
+
   return {
     coverLetters: state.coverLetters,
     currentIndex: state.currentIndex,
@@ -138,6 +208,15 @@ const useCoverLetterEdit = () => {
     isLoading: coverLetterLoading,
     isSaving,
     isSaveSuccess,
+    isGenerating,
+
+    isAiModalVisible,
+    aiGenerateCount,
+    aiErrorType,
+    openAiModal,
+    closeAiModal,
+    closeAiErrorModal,
+    handleGenerateAiCoverLetter,
 
     initializeFromServer,
     handleQuestionChange,

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -89,14 +89,12 @@ const useCoverLetterEdit = () => {
   }, [state.coverLetters]);
 
   return {
-    // 상태
     coverLetters: state.coverLetters,
     currentIndex: state.currentIndex,
     currentItem,
     isEditMode,
     coverLetterId,
 
-    // 액션
     initializeFromServer,
     handleQuestionChange,
     handleAnswerChange,

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,4 +1,11 @@
-import { useReducer, useCallback, useEffect, useState } from 'react';
+import {
+  useReducer,
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  useMemo,
+} from 'react';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { AxiosError } from 'axios';
@@ -44,6 +51,8 @@ const useCoverLetterEdit = () => {
     currentIndex: 0,
   });
 
+  const initialCoverLettersRef = useRef<CoverLetter[] | null>(null);
+
   // 서버 데이터로 초기화
   useEffect(() => {
     if (coverLetterData?.data.coverLetters) {
@@ -51,6 +60,26 @@ const useCoverLetterEdit = () => {
         type: 'INIT_FROM_SERVER',
         payload: coverLetterData.data.coverLetters,
       });
+
+      initialCoverLettersRef.current = coverLetterData.data.coverLetters.map(
+        item => {
+          if (item.coverLetterId !== null) {
+            return {
+              tempId: undefined,
+              coverLetterId: item.coverLetterId,
+              question: item.question,
+              answer: item.answer,
+            };
+          } else {
+            return {
+              tempId: item.tempId,
+              coverLetterId: null,
+              question: item.question,
+              answer: item.answer,
+            };
+          }
+        },
+      );
     }
   }, [coverLetterData]);
 
@@ -61,6 +90,17 @@ const useCoverLetterEdit = () => {
   }, []);
 
   const currentItem = state.coverLetters[state.currentIndex];
+
+  const isDirty = useMemo(() => {
+    if (!initialCoverLettersRef.current) {
+      return false;
+    }
+
+    return (
+      JSON.stringify(initialCoverLettersRef.current) !==
+      JSON.stringify(state.coverLetters)
+    );
+  }, [state.coverLetters]);
 
   // 서버에서 불러온 CoverLetter로 초기화
   const initializeFromServer = useCallback((data: CoverLetter[]) => {
@@ -233,6 +273,8 @@ const useCoverLetterEdit = () => {
     selectItem,
     getRequestData,
     handleSave,
+
+    isDirty,
   };
 };
 

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,0 +1,110 @@
+import { useReducer, useCallback } from 'react';
+
+import { RouteProp, useRoute } from '@react-navigation/native';
+
+import { CoverLetter } from '../types/CoverLetterType';
+
+import { coverLetterReducer } from './coverLetterReducer';
+
+import { RecordNavigationProps } from '@/navigation/types/navigationTypes';
+
+type EditCoverLetterRouteProp = RouteProp<
+  RecordNavigationProps,
+  'EditCoverLetter'
+>;
+
+const useCoverLetterEdit = () => {
+  const route = useRoute<EditCoverLetterRouteProp>();
+  const coverLetterId = route.params?.coverLetterId;
+  const isEditMode = coverLetterId !== undefined;
+
+  function createNewCoverLetter(): CoverLetter {
+    return {
+      coverLetterId: null,
+      tempId: new Date().toISOString(),
+      question: '',
+      answer: '',
+    };
+  }
+
+  const [state, dispatch] = useReducer(coverLetterReducer, {
+    coverLetters: [createNewCoverLetter()],
+    currentIndex: 0,
+  });
+
+  const currentItem = state.coverLetters[state.currentIndex];
+
+  // 서버에서 불러온 CoverLetter로 초기화
+  const initializeFromServer = useCallback((data: CoverLetter[]) => {
+    dispatch({ type: 'INIT_FROM_SERVER', payload: data });
+  }, []);
+
+  // 질문 변경
+  const handleQuestionChange = useCallback(
+    (text: string) => {
+      dispatch({
+        type: 'UPDATE_QUESTION',
+        payload: { index: state.currentIndex, text },
+      });
+    },
+    [state.currentIndex],
+  );
+
+  // 답변 변경
+  const handleAnswerChange = useCallback(
+    (text: string) => {
+      dispatch({
+        type: 'UPDATE_ANSWER',
+        payload: { index: state.currentIndex, text },
+      });
+    },
+    [state.currentIndex],
+  );
+
+  // 새 문항 추가
+  const handleAddItem = useCallback(() => {
+    dispatch({ type: 'ADD_ITEM', payload: createNewCoverLetter() });
+  }, []);
+
+  // 현재 문항 삭제
+  const handleDeleteItem = useCallback(() => {
+    dispatch({
+      type: 'DELETE_ITEM',
+      payload: { index: state.currentIndex },
+    });
+  }, [state.currentIndex]);
+
+  // 특정 문항 선택
+  const selectItem = useCallback((index: number) => {
+    dispatch({ type: 'SET_INDEX', payload: { index } });
+  }, []);
+
+  // 요청 데이터로 변환 (서버 전송용)
+  const getRequestData = useCallback(() => {
+    return state.coverLetters.map(item => ({
+      coverLetterId: item.coverLetterId,
+      question: item.question.trim(),
+      answer: item.answer.trim(),
+    }));
+  }, [state.coverLetters]);
+
+  return {
+    // 상태
+    coverLetters: state.coverLetters,
+    currentIndex: state.currentIndex,
+    currentItem,
+    isEditMode,
+    coverLetterId,
+
+    // 액션
+    initializeFromServer,
+    handleQuestionChange,
+    handleAnswerChange,
+    handleAddItem,
+    handleDeleteItem,
+    selectItem,
+    getRequestData,
+  };
+};
+
+export default useCoverLetterEdit;

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -51,7 +51,7 @@ const useCoverLetterEdit = () => {
 
   useEffect(() => {
     list.selectItem(coverLetterIdx ?? 0);
-  }, [coverLetterIdx]);
+  }, [coverLetterIdx, list.coverLetters.length]);
 
   return {
     coverLetters: list.coverLetters,

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,10 +1,12 @@
-import { useReducer, useCallback } from 'react';
+import { useReducer, useCallback, useEffect, useState } from 'react';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
 
 import { CoverLetter } from '../types/CoverLetterType';
 
 import { coverLetterReducer } from './coverLetterReducer';
+import useCoverLetterMutation from './useCoverLetterMutation';
+import { useCoverLetterQueries } from './useCoverLetterQueries';
 
 import { RecordNavigationProps } from '@/navigation/types/navigationTypes';
 
@@ -17,6 +19,33 @@ const useCoverLetterEdit = () => {
   const route = useRoute<EditCoverLetterRouteProp>();
   const coverLetterId = route.params?.coverLetterId;
   const isEditMode = coverLetterId !== undefined;
+  const [deleteIdList, setDeleteIdList] = useState<number[]>([]);
+
+  const { coverLetterData, coverLetterLoading } = useCoverLetterQueries();
+  const { saveCoverLetter, isSaving, isSaveSuccess, deleteCoverLetter } =
+    useCoverLetterMutation();
+
+  const [state, dispatch] = useReducer(coverLetterReducer, {
+    coverLetters: [createNewCoverLetter()],
+    currentIndex: 0,
+  });
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (coverLetterData?.data.coverLetters) {
+      dispatch({
+        type: 'INIT_FROM_SERVER',
+        payload: coverLetterData.data.coverLetters,
+      });
+    }
+  }, [coverLetterData]);
+
+  const currentItem = state.coverLetters[state.currentIndex];
+
+  // 서버에서 불러온 CoverLetter로 초기화
+  const initializeFromServer = useCallback((data: CoverLetter[]) => {
+    dispatch({ type: 'INIT_FROM_SERVER', payload: data });
+  }, []);
 
   function createNewCoverLetter(): CoverLetter {
     return {
@@ -26,18 +55,6 @@ const useCoverLetterEdit = () => {
       answer: '',
     };
   }
-
-  const [state, dispatch] = useReducer(coverLetterReducer, {
-    coverLetters: [createNewCoverLetter()],
-    currentIndex: 0,
-  });
-
-  const currentItem = state.coverLetters[state.currentIndex];
-
-  // 서버에서 불러온 CoverLetter로 초기화
-  const initializeFromServer = useCallback((data: CoverLetter[]) => {
-    dispatch({ type: 'INIT_FROM_SERVER', payload: data });
-  }, []);
 
   // 질문 변경
   const handleQuestionChange = useCallback(
@@ -68,6 +85,17 @@ const useCoverLetterEdit = () => {
 
   // 현재 문항 삭제
   const handleDeleteItem = useCallback(() => {
+    const targetId = state.coverLetters.find(
+      (item, idx) => idx === state.currentIndex,
+    )?.coverLetterId;
+
+    if (targetId !== undefined) {
+      setDeleteIdList(prev => [...prev, targetId]);
+      console.log('Deleting cover letter with ID:', targetId);
+    } else {
+      console.log('No cover letter ID to delete.');
+    }
+
     dispatch({
       type: 'DELETE_ITEM',
       payload: { index: state.currentIndex },
@@ -88,12 +116,28 @@ const useCoverLetterEdit = () => {
     }));
   }, [state.coverLetters]);
 
+  // 자기소개서 저장
+  const handleSave = useCallback(() => {
+    const requestData = getRequestData();
+
+    console.log('Saving cover letters:', requestData);
+
+    saveCoverLetter(requestData as CoverLetter[]);
+
+    deleteIdList.forEach(id => {
+      deleteCoverLetter(id);
+    });
+  }, [getRequestData, saveCoverLetter, deleteCoverLetter, deleteIdList]);
+
   return {
     coverLetters: state.coverLetters,
     currentIndex: state.currentIndex,
     currentItem,
     isEditMode,
     coverLetterId,
+    isLoading: coverLetterLoading,
+    isSaving,
+    isSaveSuccess,
 
     initializeFromServer,
     handleQuestionChange,
@@ -102,6 +146,7 @@ const useCoverLetterEdit = () => {
     handleDeleteItem,
     selectItem,
     getRequestData,
+    handleSave,
   };
 };
 

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -3,6 +3,7 @@ import { useReducer, useCallback, useEffect, useState } from 'react';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { AxiosError } from 'axios';
 
+import { getAiGenerateCount } from '../api/coverLetterApi';
 import { AiCoverLetterResponse, CoverLetter } from '../types/CoverLetterType';
 
 import { coverLetterReducer } from './coverLetterReducer';
@@ -52,6 +53,12 @@ const useCoverLetterEdit = () => {
       });
     }
   }, [coverLetterData]);
+
+  useEffect(() => {
+    getAiGenerateCount().then(data => {
+      setAiGenerateCount(data.data.coverletterCnt);
+    });
+  }, []);
 
   const currentItem = state.coverLetters[state.currentIndex];
 

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
 
@@ -17,8 +17,8 @@ type EditCoverLetterRouteProp = RouteProp<
 
 const useCoverLetterEdit = () => {
   const route = useRoute<EditCoverLetterRouteProp>();
-  const coverLetterId = route.params?.coverLetterId;
-  const isEditMode = coverLetterId !== undefined;
+  const coverLetterIdx = route.params?.coverLetterIdx;
+  const isEditMode = coverLetterIdx !== undefined;
 
   const { coverLetterData, coverLetterLoading } = useCoverLetterQueries();
 
@@ -49,12 +49,16 @@ const useCoverLetterEdit = () => {
     }
   }, [list, save]);
 
+  useEffect(() => {
+    list.selectItem(coverLetterIdx ?? 0);
+  }, [coverLetterIdx]);
+
   return {
     coverLetters: list.coverLetters,
     currentIndex: list.currentIndex,
     currentItem: list.currentItem,
     isEditMode,
-    coverLetterId,
+    coverLetterIdx,
     isLoading: coverLetterLoading,
     isSaving: save.isSaving,
     isSaveSuccess: save.isSaveSuccess,

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -214,6 +214,7 @@ const useCoverLetterEdit = () => {
         });
 
         if (result?.data?.answer) {
+          handleQuestionChange(question);
           handleAnswerChange(result.data.answer);
         }
         if (result?.data?.coverletterCnt !== undefined) {

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterEdit.ts
@@ -1,21 +1,12 @@
-import {
-  useReducer,
-  useCallback,
-  useEffect,
-  useState,
-  useRef,
-  useMemo,
-} from 'react';
+import { useCallback } from 'react';
 
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { AxiosError } from 'axios';
 
-import { getAiGenerateCount } from '../api/coverLetterApi';
-import { AiCoverLetterResponse, CoverLetter } from '../types/CoverLetterType';
-
-import { coverLetterReducer } from './coverLetterReducer';
-import useCoverLetterMutation from './useCoverLetterMutation';
+import useAiCoverLetter from './useAiCoverLetter';
+import useCoverLetterForm from './useCoverLetterForm';
+import useCoverLetterList from './useCoverLetterList';
 import { useCoverLetterQueries } from './useCoverLetterQueries';
+import useCoverLetterSave from './useCoverLetterSave';
 
 import { RecordNavigationProps } from '@/navigation/types/navigationTypes';
 
@@ -24,258 +15,60 @@ type EditCoverLetterRouteProp = RouteProp<
   'EditCoverLetter'
 >;
 
-type AiErrorType = 'limitExceeded' | 'noReview' | null;
-
 const useCoverLetterEdit = () => {
   const route = useRoute<EditCoverLetterRouteProp>();
   const coverLetterId = route.params?.coverLetterId;
   const isEditMode = coverLetterId !== undefined;
-  const [deleteIdList, setDeleteIdList] = useState<number[]>([]);
-
-  const [isAiModalVisible, setIsAiModalVisible] = useState(false);
-  const [aiGenerateCount, setAiGenerateCount] = useState(5);
-  const [aiErrorType, setAiErrorType] = useState<AiErrorType>(null);
 
   const { coverLetterData, coverLetterLoading } = useCoverLetterQueries();
-  const {
-    saveCoverLetter,
-    isSaving,
-    isSaveSuccess,
-    deleteCoverLetter,
-    generateAiCoverLetterAsync,
-    isGenerating,
-  } = useCoverLetterMutation();
 
-  const [state, dispatch] = useReducer(coverLetterReducer, {
-    coverLetters: [createNewCoverLetter()],
-    currentIndex: 0,
+  const list = useCoverLetterList({
+    initialData: coverLetterData?.data,
   });
 
-  const initialCoverLettersRef = useRef<CoverLetter[] | null>(null);
+  const form = useCoverLetterForm({
+    dispatch: list.dispatch,
+    currentIndex: list.currentIndex,
+  });
 
-  // 서버 데이터로 초기화
-  useEffect(() => {
-    if (coverLetterData?.data.coverLetters) {
-      dispatch({
-        type: 'INIT_FROM_SERVER',
-        payload: coverLetterData.data.coverLetters,
-      });
+  const save = useCoverLetterSave({
+    coverLetters: list.coverLetters,
+  });
 
-      initialCoverLettersRef.current = coverLetterData.data.coverLetters.map(
-        item => {
-          if (item.coverLetterId !== null) {
-            return {
-              tempId: undefined,
-              coverLetterId: item.coverLetterId,
-              question: item.question,
-              answer: item.answer,
-            };
-          } else {
-            return {
-              tempId: item.tempId,
-              coverLetterId: null,
-              question: item.question,
-              answer: item.answer,
-            };
-          }
-        },
-      );
-    }
-  }, [coverLetterData]);
-
-  useEffect(() => {
-    getAiGenerateCount().then(data => {
-      setAiGenerateCount(data.data.coverletterCnt);
-    });
-  }, []);
-
-  const currentItem = state.coverLetters[state.currentIndex];
-
-  const isDirty = useMemo(() => {
-    if (!initialCoverLettersRef.current) {
-      return false;
-    }
-
-    return (
-      JSON.stringify(initialCoverLettersRef.current) !==
-      JSON.stringify(state.coverLetters)
-    );
-  }, [state.coverLetters]);
-
-  // 서버에서 불러온 CoverLetter로 초기화
-  const initializeFromServer = useCallback((data: CoverLetter[]) => {
-    dispatch({ type: 'INIT_FROM_SERVER', payload: data });
-  }, []);
-
-  function createNewCoverLetter(): CoverLetter {
-    return {
-      coverLetterId: null,
-      tempId: new Date().toISOString(),
-      question: '',
-      answer: '',
-    };
-  }
-
-  // 질문 변경
-  const handleQuestionChange = useCallback(
-    (text: string) => {
-      dispatch({
-        type: 'UPDATE_QUESTION',
-        payload: { index: state.currentIndex, text },
-      });
+  const aiCoverLetter = useAiCoverLetter({
+    onSuccess: (question, answer) => {
+      form.handleQuestionChange(question);
+      form.handleAnswerChange(answer);
     },
-    [state.currentIndex],
-  );
+  });
 
-  // 답변 변경
-  const handleAnswerChange = useCallback(
-    (text: string) => {
-      dispatch({
-        type: 'UPDATE_ANSWER',
-        payload: { index: state.currentIndex, text },
-      });
-    },
-    [state.currentIndex],
-  );
-
-  // 새 문항 추가
-  const handleAddItem = useCallback(() => {
-    dispatch({ type: 'ADD_ITEM', payload: createNewCoverLetter() });
-  }, []);
-
-  // 현재 문항 삭제
   const handleDeleteItem = useCallback(() => {
-    const targetId = state.coverLetters.find(
-      (item, idx) => idx === state.currentIndex,
-    )?.coverLetterId;
-
-    if (targetId !== undefined) {
-      setDeleteIdList(prev => [...prev, targetId]);
-      console.log('Deleting cover letter with ID:', targetId);
-    } else {
-      console.log('No cover letter ID to delete.');
+    const deletedId = list.handleDeleteItem();
+    if (deletedId !== null) {
+      save.addToDeleteList(deletedId);
     }
-
-    dispatch({
-      type: 'DELETE_ITEM',
-      payload: { index: state.currentIndex },
-    });
-  }, [state.currentIndex]);
-
-  // 특정 문항 선택
-  const selectItem = useCallback((index: number) => {
-    dispatch({ type: 'SET_INDEX', payload: { index } });
-  }, []);
-
-  // 요청 데이터로 변환 (서버 전송용)
-  const getRequestData = useCallback(() => {
-    return state.coverLetters.map(item => ({
-      coverLetterId: item.coverLetterId,
-      question: item.question.trim(),
-      answer: item.answer.trim(),
-    }));
-  }, [state.coverLetters]);
-
-  // 자기소개서 저장
-  const handleSave = useCallback(() => {
-    const requestData = getRequestData();
-
-    console.log('Saving cover letters:', requestData);
-
-    saveCoverLetter(requestData as CoverLetter[]);
-
-    deleteIdList.forEach(id => {
-      deleteCoverLetter(id);
-    });
-  }, [getRequestData, saveCoverLetter, deleteCoverLetter, deleteIdList]);
-
-  // AI 모달 열기
-  const openAiModal = useCallback(() => {
-    setIsAiModalVisible(true);
-  }, []);
-
-  // AI 모달 닫기
-  const closeAiModal = useCallback(() => {
-    setIsAiModalVisible(false);
-  }, []);
-
-  // 에러 모달 닫기
-  const closeAiErrorModal = useCallback(() => {
-    setAiErrorType(null);
-  }, []);
-
-  // AI 자기소개서 생성
-  const handleGenerateAiCoverLetter = useCallback(
-    async ({ role, question }: { role: string; question: string }) => {
-      try {
-        const result: AiCoverLetterResponse = await generateAiCoverLetterAsync({
-          role,
-          question,
-        });
-
-        if (result?.data?.answer) {
-          handleQuestionChange(question);
-          handleAnswerChange(result.data.answer);
-        }
-        if (result?.data?.coverletterCnt !== undefined) {
-          setAiGenerateCount(result.data.coverletterCnt);
-        }
-        setIsAiModalVisible(false);
-
-        return result;
-      } catch (e) {
-        console.error('AI generate error:', e);
-        setIsAiModalVisible(false);
-
-        if (e instanceof AxiosError && e.response) {
-          const status = e.response.status;
-
-          if (status === 403) {
-            setAiErrorType('limitExceeded');
-            return;
-          }
-
-          if (status === 404) {
-            setAiErrorType('noReview');
-            return;
-          }
-        }
-
-        throw e;
-      }
-    },
-    [generateAiCoverLetterAsync, handleAnswerChange],
-  );
+  }, [list, save]);
 
   return {
-    coverLetters: state.coverLetters,
-    currentIndex: state.currentIndex,
-    currentItem,
+    coverLetters: list.coverLetters,
+    currentIndex: list.currentIndex,
+    currentItem: list.currentItem,
     isEditMode,
     coverLetterId,
     isLoading: coverLetterLoading,
-    isSaving,
-    isSaveSuccess,
-    isGenerating,
+    isSaving: save.isSaving,
+    isSaveSuccess: save.isSaveSuccess,
+    isDirty: list.isDirty,
 
-    isAiModalVisible,
-    aiGenerateCount,
-    aiErrorType,
-    openAiModal,
-    closeAiModal,
-    closeAiErrorModal,
-    handleGenerateAiCoverLetter,
-
-    initializeFromServer,
-    handleQuestionChange,
-    handleAnswerChange,
-    handleAddItem,
+    initializeFromServer: list.initializeFromServer,
+    handleQuestionChange: form.handleQuestionChange,
+    handleAnswerChange: form.handleAnswerChange,
+    handleAddItem: list.handleAddItem,
     handleDeleteItem,
-    selectItem,
-    getRequestData,
-    handleSave,
+    selectItem: list.selectItem,
+    handleSave: save.handleSave,
 
-    isDirty,
+    ...aiCoverLetter,
   };
 };
 

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterForm.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterForm.ts
@@ -1,0 +1,40 @@
+import { useCallback, Dispatch } from 'react';
+
+import { Action } from './coverLetterReducer';
+
+type UseCoverLetterFormParams = {
+  dispatch: Dispatch<Action>;
+  currentIndex: number;
+};
+
+const useCoverLetterForm = ({
+  dispatch,
+  currentIndex,
+}: UseCoverLetterFormParams) => {
+  const handleQuestionChange = useCallback(
+    (text: string) => {
+      dispatch({
+        type: 'UPDATE_QUESTION',
+        payload: { index: currentIndex, text },
+      });
+    },
+    [dispatch, currentIndex],
+  );
+
+  const handleAnswerChange = useCallback(
+    (text: string) => {
+      dispatch({
+        type: 'UPDATE_ANSWER',
+        payload: { index: currentIndex, text },
+      });
+    },
+    [dispatch, currentIndex],
+  );
+
+  return {
+    handleQuestionChange,
+    handleAnswerChange,
+  };
+};
+
+export default useCoverLetterForm;

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterList.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterList.ts
@@ -1,0 +1,118 @@
+import { useReducer, useCallback, useEffect, useRef, useMemo } from 'react';
+
+import { CoverLetter, CoverLetterDataResponse } from '../types/CoverLetterType';
+
+import { coverLetterReducer, Action } from './coverLetterReducer';
+
+function createNewCoverLetter(): CoverLetter {
+  return {
+    coverLetterId: null,
+    tempId: new Date().toISOString(),
+    question: '',
+    answer: '',
+  };
+}
+
+type UseCoverLetterListParams = {
+  initialData?: CoverLetterDataResponse;
+};
+
+const useCoverLetterList = ({ initialData }: UseCoverLetterListParams) => {
+  const [state, dispatch] = useReducer(coverLetterReducer, {
+    coverLetters: [createNewCoverLetter()],
+    currentIndex: 0,
+  });
+
+  const initialCoverLettersRef = useRef<CoverLetter[] | null>(null);
+
+  useEffect(() => {
+    if (initialData?.coverLetters) {
+      dispatch({
+        type: 'INIT_FROM_SERVER',
+        payload: initialData.coverLetters,
+      });
+
+      initialCoverLettersRef.current = initialData.coverLetters.map(item => {
+        if (item.coverLetterId !== null) {
+          return {
+            tempId: null,
+            coverLetterId: item.coverLetterId,
+            question: item.question,
+            answer: item.answer,
+          } as CoverLetter;
+        } else {
+          return {
+            tempId: item.tempId,
+            coverLetterId: null,
+            question: item.question,
+            answer: item.answer,
+          } as CoverLetter;
+        }
+      });
+    }
+  }, [initialData]);
+
+  const currentItem = state.coverLetters[state.currentIndex];
+
+  const isDirty = useMemo(() => {
+    const init = initialCoverLettersRef.current;
+    if (!init) {
+      return false;
+    }
+
+    if (init.length !== state.coverLetters.length) {
+      return true;
+    }
+
+    return init.some((a, idx) => {
+      const b = state.coverLetters[idx];
+      const bTempId = b.coverLetterId === null ? b.tempId : null;
+
+      return (
+        a.tempId !== bTempId ||
+        a.coverLetterId !== b.coverLetterId ||
+        a.question !== b.question ||
+        a.answer !== b.answer
+      );
+    });
+  }, [state.coverLetters]);
+
+  const selectItem = useCallback((index: number) => {
+    dispatch({ type: 'SET_INDEX', payload: { index } });
+  }, []);
+
+  const handleAddItem = useCallback(() => {
+    dispatch({ type: 'ADD_ITEM', payload: createNewCoverLetter() });
+  }, []);
+
+  const handleDeleteItem = useCallback((): number | null => {
+    const target = state.coverLetters[state.currentIndex];
+    const deletedId = target?.coverLetterId ?? null;
+
+    dispatch({
+      type: 'DELETE_ITEM',
+      payload: { index: state.currentIndex },
+    });
+
+    return deletedId;
+  }, [state.currentIndex, state.coverLetters]);
+
+  const initializeFromServer = useCallback((data: CoverLetter[]) => {
+    dispatch({ type: 'INIT_FROM_SERVER', payload: data });
+  }, []);
+
+  return {
+    coverLetters: state.coverLetters,
+    currentIndex: state.currentIndex,
+    currentItem,
+    isDirty,
+    dispatch,
+    selectItem,
+    handleAddItem,
+    handleDeleteItem,
+    initializeFromServer,
+  };
+};
+
+export type { Action };
+export default useCoverLetterList;

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
@@ -18,6 +18,7 @@ const useCoverLetterMutation = () => {
     mutationFn: (data: CoverLetter[]) => saveCoverLetter(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
+      queryClient.invalidateQueries({ queryKey: ['record'] });
     },
     onError: error => {
       console.error('자기소개서 저장 실패:', error);
@@ -28,6 +29,7 @@ const useCoverLetterMutation = () => {
     mutationFn: (coverLetterId: number) => deleteCoverLetter(coverLetterId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
+      queryClient.invalidateQueries({ queryKey: ['record'] });
     },
     onError: error => {
       console.error('자기소개서 삭제 실패:', error);

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  deleteCoverLetter,
+  generateCoverLetterByAI,
+  saveCoverLetter,
+} from '../api/coverLetterApi';
+import {
+  AiCoverLetterDataResponse,
+  AiCoverLetterRequest,
+  CoverLetter,
+} from '../types/CoverLetterType';
+
+const useCoverLetterMutation = () => {
+  const queryClient = useQueryClient();
+
+  const saveCoverLetterMutation = useMutation({
+    mutationFn: (data: CoverLetter[]) => saveCoverLetter(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
+    },
+    onError: error => {
+      console.error('자기소개서 저장 실패:', error);
+    },
+  });
+
+  const deleteCoverLetterMutation = useMutation({
+    mutationFn: (coverLetterId: number) => deleteCoverLetter(coverLetterId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
+    },
+    onError: error => {
+      console.error('자기소개서 삭제 실패:', error);
+    },
+  });
+
+  const generateAiCoverLetterMutation = useMutation<
+    AiCoverLetterDataResponse,
+    Error,
+    AiCoverLetterRequest
+  >({
+    mutationFn: ({ role, question }: AiCoverLetterRequest) =>
+      generateCoverLetterByAI({ role, question }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
+    },
+    onError: error => {
+      console.error('AI 자기소개서 생성 실패:', error);
+    },
+  });
+
+  return {
+    saveCoverLetter: saveCoverLetterMutation.mutate,
+    saveCoverLetterAsync: saveCoverLetterMutation.mutateAsync,
+    isSaving: saveCoverLetterMutation.isPending,
+    saveError: saveCoverLetterMutation.error,
+    isSaveSuccess: saveCoverLetterMutation.isSuccess,
+
+    deleteCoverLetter: deleteCoverLetterMutation.mutate,
+    deleteCoverLetterAsync: deleteCoverLetterMutation.mutateAsync,
+    isDeleting: deleteCoverLetterMutation.isPending,
+    deleteError: deleteCoverLetterMutation.error,
+    isDeleteSuccess: deleteCoverLetterMutation.isSuccess,
+
+    generateAiCoverLetter: generateAiCoverLetterMutation.mutate,
+    generateAiCoverLetterAsync: generateAiCoverLetterMutation.mutateAsync,
+    isGenerating: generateAiCoverLetterMutation.isPending,
+    generateError: generateAiCoverLetterMutation.error,
+    isGenerateSuccess: generateAiCoverLetterMutation.isSuccess,
+    generatedAnswer: generateAiCoverLetterMutation.data?.answer,
+  };
+};
+
+export default useCoverLetterMutation;

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
@@ -41,9 +41,6 @@ const useCoverLetterMutation = () => {
   >({
     mutationFn: ({ role, question }: AiCoverLetterRequest) =>
       generateCoverLetterByAI({ role, question }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['coverLetter'] });
-    },
     onError: error => {
       console.error('AI 자기소개서 생성 실패:', error);
     },

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterMutation.ts
@@ -6,8 +6,8 @@ import {
   saveCoverLetter,
 } from '../api/coverLetterApi';
 import {
-  AiCoverLetterDataResponse,
   AiCoverLetterRequest,
+  AiCoverLetterResponse,
   CoverLetter,
 } from '../types/CoverLetterType';
 
@@ -35,7 +35,7 @@ const useCoverLetterMutation = () => {
   });
 
   const generateAiCoverLetterMutation = useMutation<
-    AiCoverLetterDataResponse,
+    AiCoverLetterResponse,
     Error,
     AiCoverLetterRequest
   >({
@@ -67,7 +67,6 @@ const useCoverLetterMutation = () => {
     isGenerating: generateAiCoverLetterMutation.isPending,
     generateError: generateAiCoverLetterMutation.error,
     isGenerateSuccess: generateAiCoverLetterMutation.isSuccess,
-    generatedAnswer: generateAiCoverLetterMutation.data?.answer,
   };
 };
 

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterQueries.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterQueries.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCoverLetter } from '../api/coverLetterApi';
+import { CoverLetterResponse } from '../types/CoverLetterType';
+
+const useCoverLetterQueries = () => {
+  const coverLetterQuery = useQuery<CoverLetterResponse>({
+    queryKey: ['coverLetter'],
+    queryFn: getCoverLetter,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  return {
+    coverLetterData: coverLetterQuery.data,
+    coverLetterLoading: coverLetterQuery.isLoading,
+    coverLetterError: coverLetterQuery.isError,
+    refetchCoverLetter: coverLetterQuery.refetch,
+  };
+};
+
+export { useCoverLetterQueries };

--- a/src/features/record/editCoverLetter/hooks/useCoverLetterSave.ts
+++ b/src/features/record/editCoverLetter/hooks/useCoverLetterSave.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+import { CoverLetter } from '../types/CoverLetterType';
+
+import useCoverLetterMutation from './useCoverLetterMutation';
+
+type UseCoverLetterSaveParams = {
+  coverLetters: CoverLetter[];
+};
+
+const useCoverLetterSave = ({ coverLetters }: UseCoverLetterSaveParams) => {
+  const [deleteIdList, setDeleteIdList] = useState<number[]>([]);
+
+  const { saveCoverLetter, isSaving, isSaveSuccess, deleteCoverLetter } =
+    useCoverLetterMutation();
+
+  const addToDeleteList = useCallback((id: number) => {
+    setDeleteIdList(prev => [...prev, id]);
+  }, []);
+
+  const getRequestData = useCallback(() => {
+    return coverLetters.map(item => ({
+      coverLetterId: item.coverLetterId,
+      question: item.question.trim(),
+      answer: item.answer.trim(),
+    }));
+  }, [coverLetters]);
+
+  const handleSave = useCallback(() => {
+    const requestData = getRequestData();
+    saveCoverLetter(requestData as CoverLetter[]);
+    deleteIdList.forEach(id => {
+      deleteCoverLetter(id);
+    });
+  }, [getRequestData, saveCoverLetter, deleteCoverLetter, deleteIdList]);
+
+  return {
+    handleSave,
+    addToDeleteList,
+    isSaving,
+    isSaveSuccess,
+  };
+};
+
+export default useCoverLetterSave;

--- a/src/features/record/editCoverLetter/types/CoverLetterType.ts
+++ b/src/features/record/editCoverLetter/types/CoverLetterType.ts
@@ -1,0 +1,40 @@
+import { ResponseTypes } from '@/shared/api/types';
+
+export type CoverLetter =
+  | {
+      coverLetterId: number;
+      tempId: null;
+      question: string;
+      answer: string;
+    }
+  | {
+      coverLetterId: null;
+      tempId: string;
+      question: string;
+      answer: string;
+    };
+
+export interface CoverLetterRequest {
+  coverLetterId: number | null;
+  question: string;
+  answer: string;
+}
+
+export interface CoverLetterDataResponse {
+  coverLetters: CoverLetter[];
+  coverletterCnt: number;
+}
+
+export type CoverLetterResponse = ResponseTypes<CoverLetterRequest[]>;
+
+export interface AiCoverLetterRequest {
+  role: string;
+  question: string;
+}
+
+export interface AiCoverLetterDataResponse {
+  answer: string;
+  coverletterCnt: number;
+}
+
+export type AiCoverLetterResponse = ResponseTypes<AiCoverLetterDataResponse>;

--- a/src/features/record/editCoverLetter/types/CoverLetterType.ts
+++ b/src/features/record/editCoverLetter/types/CoverLetterType.ts
@@ -25,7 +25,7 @@ export interface CoverLetterDataResponse {
   coverletterCnt: number;
 }
 
-export type CoverLetterResponse = ResponseTypes<CoverLetterRequest[]>;
+export type CoverLetterResponse = ResponseTypes<CoverLetterDataResponse>;
 
 export interface AiCoverLetterRequest {
   role: string;

--- a/src/features/record/editCoverLetter/types/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/types/components/EditCoverLetter.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { Text } from 'react-native';
+
+const EditCoverLetter = () => {
+  return <Text>Edit Cover Letter Screen</Text>;
+};
+
+export default EditCoverLetter;

--- a/src/features/record/editCoverLetter/types/components/EditCoverLetter.tsx
+++ b/src/features/record/editCoverLetter/types/components/EditCoverLetter.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-import { Text } from 'react-native';
-
-const EditCoverLetter = () => {
-  return <Text>Edit Cover Letter Screen</Text>;
-};
-
-export default EditCoverLetter;

--- a/src/features/record/editResume/hooks/useResumeMutation.ts
+++ b/src/features/record/editResume/hooks/useResumeMutation.ts
@@ -16,6 +16,7 @@ const useResumeMutation = () => {
       postResume({ resumeData, photo }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['resumeData'] });
+      queryClient.invalidateQueries({ queryKey: ['record'] });
     },
     onError: error => {
       console.error('이력서 저장 실패:', error);

--- a/src/navigation/stacks/RecordStackNavigation.tsx
+++ b/src/navigation/stacks/RecordStackNavigation.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Text } from 'react-native';
 
 import { RecordNavigationProps } from '../types/navigationTypes';
 
@@ -30,6 +31,9 @@ const RecordRoute = () => {
       <Stack.Screen name="EditCareer" component={CareerEditView} />
       <Stack.Screen name="CreateProject" component={ProjectEditView} />
       <Stack.Screen name="EditProject" component={ProjectEditView} />
+
+      <Stack.Screen name="CreateCoverLetter" component={() => <Text />} />
+      <Stack.Screen name="EditCoverLetter" component={() => <Text />} />
     </Stack.Navigator>
   );
 };

--- a/src/navigation/stacks/RecordStackNavigation.tsx
+++ b/src/navigation/stacks/RecordStackNavigation.tsx
@@ -4,7 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { RecordNavigationProps } from '../types/navigationTypes';
 
-import EditCoverLetter from '@/features/record/editCoverLetter/types/components/EditCoverLetter';
+import EditCoverLetter from '@/features/record/editCoverLetter/components/EditCoverLetter';
 import AchievementEditView from '@/screens/Record/EditView/AchievementEditView';
 import CareerEditView from '@/screens/Record/EditView/CareerEditView';
 import EducationEditView from '@/screens/Record/EditView/EducationEditView';

--- a/src/navigation/stacks/RecordStackNavigation.tsx
+++ b/src/navigation/stacks/RecordStackNavigation.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Text } from 'react-native';
 
 import { RecordNavigationProps } from '../types/navigationTypes';
 
+import EditCoverLetter from '@/features/record/editCoverLetter/types/components/EditCoverLetter';
 import AchievementEditView from '@/screens/Record/EditView/AchievementEditView';
 import CareerEditView from '@/screens/Record/EditView/CareerEditView';
 import EducationEditView from '@/screens/Record/EditView/EducationEditView';
@@ -32,8 +32,8 @@ const RecordRoute = () => {
       <Stack.Screen name="CreateProject" component={ProjectEditView} />
       <Stack.Screen name="EditProject" component={ProjectEditView} />
 
-      <Stack.Screen name="CreateCoverLetter" component={() => <Text />} />
-      <Stack.Screen name="EditCoverLetter" component={() => <Text />} />
+      <Stack.Screen name="CreateCoverLetter" component={EditCoverLetter} />
+      <Stack.Screen name="EditCoverLetter" component={EditCoverLetter} />
     </Stack.Navigator>
   );
 };

--- a/src/navigation/types/navigationTypes.ts
+++ b/src/navigation/types/navigationTypes.ts
@@ -88,7 +88,7 @@ export type RecordNavigationProps = {
   EditProject: { projectId?: number; tempId?: string };
 
   CreateCoverLetter: undefined;
-  EditCoverLetter: { coverLetterId: number };
+  EditCoverLetter: { coverLetterIdx: number };
 };
 
 export type MainStackNavigationProp =

--- a/src/navigation/types/navigationTypes.ts
+++ b/src/navigation/types/navigationTypes.ts
@@ -86,6 +86,9 @@ export type RecordNavigationProps = {
   EditCareer: { careerId?: number; tempId?: string };
   CreateProject: undefined;
   EditProject: { projectId?: number; tempId?: string };
+
+  CreateCoverLetter: undefined;
+  EditCoverLetter: { coverLetterId?: number; tempId?: string };
 };
 
 export type MainStackNavigationProp =

--- a/src/navigation/types/navigationTypes.ts
+++ b/src/navigation/types/navigationTypes.ts
@@ -88,7 +88,7 @@ export type RecordNavigationProps = {
   EditProject: { projectId?: number; tempId?: string };
 
   CreateCoverLetter: undefined;
-  EditCoverLetter: { coverLetterId?: number; tempId?: string };
+  EditCoverLetter: { coverLetterId: number };
 };
 
 export type MainStackNavigationProp =

--- a/src/screens/Record/CoverLetterView.tsx
+++ b/src/screens/Record/CoverLetterView.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import { useNavigation } from '@react-navigation/native';
 import { View, Text, Pressable } from 'react-native';
 
 import CoverLetterList from '@/features/record/coverLetterList/components/CoverLetterList';
+import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import PlusIcon from '@/static/icons/add.svg';
 
 interface Props {
@@ -11,6 +13,8 @@ interface Props {
 }
 
 const CoverLetterSection = ({ coverLetters, isExist }: Props) => {
+  const navigation = useNavigation<MainStackNavigationProp>();
+
   return (
     <View className="w-full">
       <View className="mt-[42px] flex-row items-center px-5">
@@ -25,7 +29,13 @@ const CoverLetterSection = ({ coverLetters, isExist }: Props) => {
             아직 작성한 자기소개서가 없어요.
           </Text>
 
-          <Pressable className="mt-[15px] flex-row items-center rounded-full bg-primary-purple px-[27px] py-[14px]">
+          <Pressable
+            className="mt-[15px] flex-row items-center rounded-full bg-primary-purple px-[27px] py-[14px]"
+            onPress={() =>
+              navigation.navigate('RecordRoute', {
+                screen: 'CreateCoverLetter',
+              })
+            }>
             <PlusIcon width={16} height={16} color="#DADADA" />
             <Text className="ml-[7px] text-surface-200 typo-body-17-semibold">
               새 자기소개서 작성하기

--- a/src/screens/Record/CoverLetterView.tsx
+++ b/src/screens/Record/CoverLetterView.tsx
@@ -4,7 +4,6 @@ import { View, Text, Pressable } from 'react-native';
 
 import CoverLetterList from '@/features/record/coverLetterList/components/CoverLetterList';
 import PlusIcon from '@/static/icons/add.svg';
-import ChevronRightIcon from '@/static/icons/right_chevron.svg';
 
 interface Props {
   coverLetters: { question: string; answer: string }[];
@@ -18,15 +17,6 @@ const CoverLetterSection = ({ coverLetters, isExist }: Props) => {
         <Text className="text-main-text typo-sub-title-22-bold">
           내 자기소개서
         </Text>
-
-        {isExist && (
-          <ChevronRightIcon
-            height={14}
-            width={8}
-            color="#B7B7B7"
-            className="ml-3"
-          />
-        )}
       </View>
 
       {!isExist && (

--- a/src/screens/Record/ResumeView.tsx
+++ b/src/screens/Record/ResumeView.tsx
@@ -5,7 +5,6 @@ import { View, Text, Pressable, Image } from 'react-native';
 
 import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import PlusIcon from '@/static/icons/add.svg';
-import ChevronRightIcon from '@/static/icons/right_chevron.svg';
 
 interface Props {
   title?: string;
@@ -20,15 +19,6 @@ const ResumeSection = ({ title, imageUrl, isExist }: Props) => {
     <View className="w-full">
       <View className="mt-[50px] flex-row items-center px-5">
         <Text className="text-main-text typo-sub-title-22-bold">내 이력서</Text>
-
-        {isExist && (
-          <ChevronRightIcon
-            height={14}
-            width={8}
-            color="#B7B7B7"
-            className="ml-3"
-          />
-        )}
       </View>
 
       {!isExist && (

--- a/src/screens/Record/ResumeView.tsx
+++ b/src/screens/Record/ResumeView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 import { View, Text, Pressable, Image } from 'react-native';
+import Config from 'react-native-config';
 
 import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import PlusIcon from '@/static/icons/add.svg';
@@ -53,7 +54,7 @@ const ResumeSection = ({ title, imageUrl, isExist }: Props) => {
           </View>
 
           <Image
-            source={{ uri: imageUrl }}
+            source={{ uri: Config.API_KEY + imageUrl }}
             resizeMode="cover"
             className="absolute right-[40px] top-[-29px] h-[72px] w-[72px] rounded-full border-2 border-white"
           />

--- a/src/screens/Record/ResumeView.tsx
+++ b/src/screens/Record/ResumeView.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 import { View, Text, Pressable, Image } from 'react-native';
-import Config from 'react-native-config';
 
+import { getImageSource } from '@/features/record/editResume/utils/imageUtils';
 import { MainStackNavigationProp } from '@/navigation/types/navigationTypes';
 import PlusIcon from '@/static/icons/add.svg';
 
@@ -54,7 +54,7 @@ const ResumeSection = ({ title, imageUrl, isExist }: Props) => {
           </View>
 
           <Image
-            source={{ uri: Config.API_KEY + imageUrl }}
+            source={getImageSource(imageUrl ?? null)}
             resizeMode="cover"
             className="absolute right-[40px] top-[-29px] h-[72px] w-[72px] rounded-full border-2 border-white"
           />


### PR DESCRIPTION
## 이슈 번호

- #79 

## 작업 내용 및 테스트 방법

### hook 분리

```
EditCoverLetter (Component)
└── useCoverLetterEdit (통합)
    ├── useCoverLetterQueries (Data Fetching)
    ├── useCoverLetterList (State Management - Reducer)
    │   └── coverLetterReducer (Pure Logic)
    ├── useCoverLetterForm (Input Handling)
    ├── useAiCoverLetter (AI Logic)
    │    └── useCoverLetterMutation (React Query Mutation)
    └── useCoverLetterSave (Mutation Handling)
        └── useCoverLetterMutation (React Query Mutation)
```

## Hooks 역할 및 연결 구조

### useCoverLetterEdit (중앙 제어 / Facade)
- EditCoverLetter 화면에서 사용하는 단일 진입점
- 하위 Hook들을 조합해 UI에 필요한 데이터와 핸들러만 노출
- 개별 Hook 간 의존성을 UI 컴포넌트로부터 분리

연결
- useCoverLetterList의 상태 및 제어 로직
- useCoverLetterForm의 입력 핸들러
- useAiCoverLetter, useCoverLetterSave의 사이드 이펙트

---

### useCoverLetterList & coverLetterReducer (데이터의 원천)
- useReducer 기반으로 자기소개서 리스트 상태 관리
- 추가, 삭제, 수정, 초기화 로직을 단일 Reducer에 집중
- 현재 선택된 index 및 dirty 상태 관리

연결
- dispatch를 외부로 노출
- useCoverLetterForm에서 dispatch를 호출해 리스트 상태 직접 수정

---

### useCoverLetterForm (입력 인터페이스)
- 현재 선택된 문항의 question, answer 입력 처리
- 자체 상태를 가지지 않고 리스트 상태만 변경

연결
- 입력 이벤트 발생 시 useCoverLetterList.dispatch 호출
- 특정 index의 데이터 업데이트

---

### useAiCoverLetter (외부 데이터 주입)
- AI API 호출 및 결과 수신 담당

연결
- AI 생성 성공 시 onSuccess 콜백 실행
- useCoverLetterForm의 핸들러를 호출해 사용자 입력과 동일한 경로로 상태 반영

---

### useCoverLetterSave (비즈니스 트랜잭션)
- 현재 리스트 상태와 삭제 대기 목록(deleteIdList)을 기준으로 저장 로직 수행
- 저장과 삭제를 하나의 저장 행위로 처리

연결
- 성공 시 전역 쿼리 무효화(record, coverLetter)

---


## To reviewers

- 이력서에서 너무 코드가 난잡하게 작성된것 같아서 좀 다른 방식으로 처리해 보았습니다.
