### PR TITLE
⛑️ QA: 캘린더 QA

### DIFF
--- a/src/features/calendar/editSchedule/components/ScheduleMemoInput.tsx
+++ b/src/features/calendar/editSchedule/components/ScheduleMemoInput.tsx
@@ -30,6 +30,7 @@ const ScheduleMemoInput = ({
         placeholder="메모를 입력해주세요"
         onFocus={onFocus}
         multiline={true}
+        maxLength={500}
         className="mt-[10px] rounded-[15px] bg-surface-100 px-[11px] py-[14px] text-main-text typo-body-15-regular"
         style={{
           minHeight: 100,

--- a/src/features/calendar/editSchedule/hooks/useEditSchedule.ts
+++ b/src/features/calendar/editSchedule/hooks/useEditSchedule.ts
@@ -11,12 +11,6 @@ interface UseEditScheduleProps {
   initialData: Schedule | ScheduleDatePayload;
 }
 
-/**
- * 이 훅은 일정 수정, 생성을 담당합니다.
- * - 일정의 초기 상태를 로딩합니다. *
- * - 처음 진입한 시점과 다르게 일정이 수정된 경우 이를 감지하여 사용자에게 알립니다. *
- * - 일정이 성공적으로 수정 또는 생성된 후, 관련 데이터를 갱신합니다. *
- */
 const useEditSchedule = ({ initialData }: UseEditScheduleProps) => {
   const { createSchedule, updateSchedule } = useScheduleSaveQueries();
   const { deleteSchedule } = useScheduleDeleteQueries();
@@ -33,12 +27,14 @@ const useEditSchedule = ({ initialData }: UseEditScheduleProps) => {
           memo: initialData.memo,
         };
       } else {
+        const endDate = new Date(new Date().toISOString());
+        endDate.setMinutes(0, 0, 0);
+        endDate.setHours(endDate.getHours() + 1);
+
         return {
           id: null,
-          startDate: new Date(initialData.ISODateString),
-          endDate: new Date(
-            new Date(initialData.ISODateString).getTime() + 60 * 60 * 1000,
-          ),
+          startDate: new Date(),
+          endDate: endDate,
           category: null,
           detail: '',
           memo: '',

--- a/src/features/calendar/shared/utils/buildScheduleMap.ts
+++ b/src/features/calendar/shared/utils/buildScheduleMap.ts
@@ -1,11 +1,30 @@
-import { CalendarSchedule } from '../types';
+import { Schedule } from '../types';
 
 import dayjs from '@/shared/lib/dayjs';
 
-const buildScheduleMap = (items: CalendarSchedule[]) => {
-  const map: Record<string, CalendarSchedule[]> = {};
+const buildScheduleMap = (items: Schedule[]) => {
+  const map: Record<string, Schedule[]> = {};
 
-  items.forEach(item => {
+  const sortedItems = [...items].sort((a, b) => {
+    const startA = dayjs(a.startDate);
+    const startB = dayjs(b.startDate);
+
+    if (!startA.isValid()) {
+      return 1;
+    }
+
+    if (!startB.isValid()) {
+      return -1;
+    }
+
+    if (startA.isSame(startB)) {
+      return -1;
+    }
+
+    return startA.diff(startB);
+  });
+
+  sortedItems.forEach(item => {
     const start = dayjs(item.startDate);
     const end = dayjs(item.endDate);
 


### PR DESCRIPTION
## 이슈 번호

- #95 

## 작업 내용 및 테스트 방법

### 일정이 노출되는 순서를 변경하였습니다!
sort 내부에 별도의 로직을 추가하여, 다양한 경우에 대응이 가능하도록 수정했습니다.

- 일정이 빠른 순으로 노출되는가? (최신순이 아니라 빠른 순)
- 일정이 빠른 순이 같다면 최근 등록한 순으로 노출되는가?

현재 이 상황을 가정하고 있습니다.

### ETC
- 메모 500자 제한
- 시간 노출 시 현재 해당되는 시간에서 무조건 올림한 시간(예시-현재시간이 12시 1분이면 1시 노출), 1시간 후 시간이 노출되는가?

## To reviewe

- 로직이 복잡하지 않아서, 코드만 보셔도 바로 알수 있을듯 합니다!